### PR TITLE
Feature/ivr templates

### DIFF
--- a/apps/aa/src/app/app.module.ts
+++ b/apps/aa/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { ChainModule } from '../chain/chain.module';
 import { OtpModule } from '../otp/otp.module';
 import { FundallocationModule } from '../fundallocation/fundallocation.module';
 import { GroupCashTransferModule } from '../group-cash-transfer/group-cash-transfer.module';
+import { IvrTemplatesModule } from '../ivr-templates/ivr-templates.module';
 import { StellarSponsorModule } from '../stellar-sponsor/stellar-sponsor.module';
 
 @Module({
@@ -100,6 +101,7 @@ import { StellarSponsorModule } from '../stellar-sponsor/stellar-sponsor.module'
     GrievancesModule,
     InkindsModule,
     GroupCashTransferModule,
+    IvrTemplatesModule,
     OtpModule,
     FundallocationModule,
   ],

--- a/apps/aa/src/constants/index.ts
+++ b/apps/aa/src/constants/index.ts
@@ -273,6 +273,13 @@ export const JOBS = {
     UPDATE_STATUS: 'aa.jobs.grievances.updateStatus',
     GET_OVERVIEW_STATS: 'aa.jobs.grievances.getOverviewStats',
   },
+  IVR_TEMPLATES: {
+    CREATE: 'aa.jobs.ivrTemplates.create',
+    LIST: 'aa.jobs.ivrTemplates.list',
+    GET: 'aa.jobs.ivrTemplates.get',
+    UPDATE: 'aa.jobs.ivrTemplates.update',
+    DELETE: 'aa.jobs.ivrTemplates.delete',
+  },
   EVM: {
     // Generic dispatcher job names — all EVM jobs route through one of these two
     TX_JOB: `aa.jobs.evm.tx_${process.env.PROJECT_ID}`, // write ops: serial (concurrency 1), signer required

--- a/apps/aa/src/constants/index.ts
+++ b/apps/aa/src/constants/index.ts
@@ -279,6 +279,7 @@ export const JOBS = {
     GET: 'aa.jobs.ivrTemplates.get',
     UPDATE: 'aa.jobs.ivrTemplates.update',
     DELETE: 'aa.jobs.ivrTemplates.delete',
+    SEND_TEST_CALL: 'aa.jobs.ivrTemplates.sendTestCall',
   },
   EVM: {
     // Generic dispatcher job names — all EVM jobs route through one of these two

--- a/apps/aa/src/ivr-templates/dto/create-ivr-template.dto.ts
+++ b/apps/aa/src/ivr-templates/dto/create-ivr-template.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateIvrTemplateDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  flowUrl?: string;
+}

--- a/apps/aa/src/ivr-templates/dto/send-test-call.dto.ts
+++ b/apps/aa/src/ivr-templates/dto/send-test-call.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class SendTestCallDto {
+  @IsString()
+  @IsNotEmpty()
+  phoneNumber: string;
+
+  @IsString()
+  @IsNotEmpty()
+  flowUrl: string;
+}

--- a/apps/aa/src/ivr-templates/dto/update-ivr-template.dto.ts
+++ b/apps/aa/src/ivr-templates/dto/update-ivr-template.dto.ts
@@ -1,0 +1,28 @@
+import { IsOptional, IsInt, IsString, IsEnum } from 'class-validator';
+
+export enum IvrTemplateStatus {
+  DRAFT = 'DRAFT',
+  ACTIVE = 'ACTIVE',
+  ARCHIVED = 'ARCHIVED',
+}
+
+export class UpdateIvrTemplateDto {
+  @IsInt()
+  id: number;
+
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  flowUrl?: string;
+
+  @IsOptional()
+  @IsEnum(IvrTemplateStatus)
+  status?: IvrTemplateStatus;
+}

--- a/apps/aa/src/ivr-templates/ivr-templates.controller.ts
+++ b/apps/aa/src/ivr-templates/ivr-templates.controller.ts
@@ -1,0 +1,53 @@
+import { Controller, UsePipes, ValidationPipe } from '@nestjs/common';
+import { MessagePattern, Payload } from '@nestjs/microservices';
+import { JOBS } from '../constants';
+import { CreateIvrTemplateDto } from './dto/create-ivr-template.dto';
+import { UpdateIvrTemplateDto } from './dto/update-ivr-template.dto';
+import { IvrTemplatesService } from './ivr-templates.service';
+
+@Controller()
+export class IvrTemplatesController {
+  constructor(private readonly ivrTemplatesService: IvrTemplatesService) {}
+
+  @MessagePattern({
+    cmd: JOBS.IVR_TEMPLATES.CREATE,
+    uuid: process.env.PROJECT_ID,
+  })
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  create(@Payload() data: CreateIvrTemplateDto) {
+    return this.ivrTemplatesService.create(data);
+  }
+
+  @MessagePattern({
+    cmd: JOBS.IVR_TEMPLATES.LIST,
+    uuid: process.env.PROJECT_ID,
+  })
+  findAll() {
+    return this.ivrTemplatesService.findAll();
+  }
+
+  @MessagePattern({
+    cmd: JOBS.IVR_TEMPLATES.GET,
+    uuid: process.env.PROJECT_ID,
+  })
+  findOne(@Payload() payload: { id: number }) {
+    return this.ivrTemplatesService.findOne(payload.id);
+  }
+
+  @MessagePattern({
+    cmd: JOBS.IVR_TEMPLATES.UPDATE,
+    uuid: process.env.PROJECT_ID,
+  })
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  update(@Payload() data: UpdateIvrTemplateDto) {
+    return this.ivrTemplatesService.update(data);
+  }
+
+  @MessagePattern({
+    cmd: JOBS.IVR_TEMPLATES.DELETE,
+    uuid: process.env.PROJECT_ID,
+  })
+  remove(@Payload() payload: { id: number }) {
+    return this.ivrTemplatesService.remove(payload.id);
+  }
+}

--- a/apps/aa/src/ivr-templates/ivr-templates.controller.ts
+++ b/apps/aa/src/ivr-templates/ivr-templates.controller.ts
@@ -3,6 +3,7 @@ import { MessagePattern, Payload } from '@nestjs/microservices';
 import { JOBS } from '../constants';
 import { CreateIvrTemplateDto } from './dto/create-ivr-template.dto';
 import { UpdateIvrTemplateDto } from './dto/update-ivr-template.dto';
+import { SendTestCallDto } from './dto/send-test-call.dto';
 import { IvrTemplatesService } from './ivr-templates.service';
 
 @Controller()
@@ -49,5 +50,13 @@ export class IvrTemplatesController {
   })
   remove(@Payload() payload: { id: number }) {
     return this.ivrTemplatesService.remove(payload.id);
+  }
+
+  @MessagePattern({
+    cmd: JOBS.IVR_TEMPLATES.SEND_TEST_CALL,
+    uuid: process.env.PROJECT_ID,
+  })
+  sendTestCall(@Payload() data: SendTestCallDto) {
+    return this.ivrTemplatesService.sendTestCall(data);
   }
 }

--- a/apps/aa/src/ivr-templates/ivr-templates.module.ts
+++ b/apps/aa/src/ivr-templates/ivr-templates.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { IvrTemplatesController } from './ivr-templates.controller';
+import { IvrTemplatesService } from './ivr-templates.service';
+
+@Module({
+  controllers: [IvrTemplatesController],
+  providers: [IvrTemplatesService],
+  exports: [IvrTemplatesService],
+})
+export class IvrTemplatesModule {}

--- a/apps/aa/src/ivr-templates/ivr-templates.service.ts
+++ b/apps/aa/src/ivr-templates/ivr-templates.service.ts
@@ -1,14 +1,22 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
+import { TriggerType } from '@rumsan/connect';
 import { IvrStatus } from '@prisma/client';
 import { PrismaService } from '@rumsan/prisma';
 import { CreateIvrTemplateDto } from './dto/create-ivr-template.dto';
 import { UpdateIvrTemplateDto } from './dto/update-ivr-template.dto';
+import { SendTestCallDto } from './dto/send-test-call.dto';
+import { CommsClient } from '../comms/comms.service';
 
 @Injectable()
 export class IvrTemplatesService {
   private readonly logger = new Logger(IvrTemplatesService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject('COMMS_CLIENT')
+    private commsClient: CommsClient,
+  ) {}
 
   async create(dto: CreateIvrTemplateDto) {
     try {
@@ -70,6 +78,34 @@ export class IvrTemplatesService {
         where: { id },
         data: { status: IvrStatus.ARCHIVED },
       });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async sendTestCall(dto: SendTestCallDto) {
+    try {
+      const { data: transports } = await this.commsClient.transport.list();
+      const voiceTransport = transports.find((t) => t.type === 'VOICE');
+
+      if (!voiceTransport?.cuid) {
+        throw new RpcException('Voice transport not found');
+      }
+
+      const { data: sessionData } = await this.commsClient.broadcast.create({
+        addresses: [dto.phoneNumber],
+        maxAttempts: 1,
+        message: {
+          content: dto.flowUrl,
+          meta: { subject: 'INFO' },
+        },
+        options: {},
+        transport: voiceTransport.cuid,
+        trigger: TriggerType.IMMEDIATE,
+      });
+
+      return sessionData;
     } catch (error) {
       this.logger.error(error);
       throw error;

--- a/apps/aa/src/ivr-templates/ivr-templates.service.ts
+++ b/apps/aa/src/ivr-templates/ivr-templates.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { IvrStatus } from '@prisma/client';
+import { PrismaService } from '@rumsan/prisma';
+import { CreateIvrTemplateDto } from './dto/create-ivr-template.dto';
+import { UpdateIvrTemplateDto } from './dto/update-ivr-template.dto';
+
+@Injectable()
+export class IvrTemplatesService {
+  private readonly logger = new Logger(IvrTemplatesService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateIvrTemplateDto) {
+    try {
+      const data = {
+        name: dto.name,
+        description: dto.description,
+        flowUrl: dto.flowUrl,
+        ...(dto.flowUrl && { status: IvrStatus.ACTIVE }),
+      };
+      return this.prisma.ivrTemplate.create({ data });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async findAll() {
+    try {
+      return this.prisma.ivrTemplate.findMany({
+        orderBy: { createdAt: 'desc' },
+      });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async findOne(id: number) {
+    try {
+      return this.prisma.ivrTemplate.findUnique({
+        where: { id },
+      });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async update(dto: UpdateIvrTemplateDto) {
+    try {
+      const { id, ...data } = dto;
+      const updateData: any = { ...data };
+      if (data.flowUrl) {
+        updateData.status = IvrStatus.ACTIVE;
+      }
+      return this.prisma.ivrTemplate.update({
+        where: { id },
+        data: updateData,
+      });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+
+  async remove(id: number) {
+    try {
+      return this.prisma.ivrTemplate.update({
+        where: { id },
+        data: { status: IvrStatus.ARCHIVED },
+      });
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
+}

--- a/apps/aa/src/ivr-templates/ivr-templates.service.ts
+++ b/apps/aa/src/ivr-templates/ivr-templates.service.ts
@@ -15,7 +15,7 @@ export class IvrTemplatesService {
   constructor(
     private readonly prisma: PrismaService,
     @Inject('COMMS_CLIENT')
-    private commsClient: CommsClient,
+    private commsClient: CommsClient
   ) {}
 
   async create(dto: CreateIvrTemplateDto) {
@@ -98,7 +98,7 @@ export class IvrTemplatesService {
         maxAttempts: 1,
         message: {
           content: dto.flowUrl,
-          meta: { subject: 'INFO' },
+          meta: { type: 'new-ivr' },
         },
         options: {},
         transport: voiceTransport.cuid,

--- a/prisma/migrations/20260723102422_aa_ivr_templates/migration.sql
+++ b/prisma/migrations/20260723102422_aa_ivr_templates/migration.sql
@@ -1,0 +1,15 @@
+-- CreateEnum
+CREATE TYPE "IvrStatus" AS ENUM ('DRAFT', 'ACTIVE', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "tbl_ivr_templates" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "flowUrl" TEXT,
+    "status" "IvrStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "tbl_ivr_templates_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -949,3 +949,25 @@ model GroupCashTransferRecord {
 }
 
 // ============== End Group Cash Transfer Schemas ================
+
+// ++++++++++++++++++ START: IVR Templates ++++++++++++++++++++
+
+model IvrTemplate {
+  id          Int       @id @default(autoincrement())
+  name        String
+  description String?
+  flowUrl     String?
+  status      IvrStatus @default(DRAFT)
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@map("tbl_ivr_templates")
+}
+
+enum IvrStatus {
+  DRAFT
+  ACTIVE
+  ARCHIVED
+}
+
+// ++++++++++++++++++ END: IVR Templates ++++++++++++++++++++


### PR DESCRIPTION
## Summary

Added backend support for IVR template management with CRUD operations.

## Changes

- Added `IvrTemplate` Prisma model.
- Added `IvrStatus` enum with the following values:
  - `DRAFT`
  - `ACTIVE`
  - `ARCHIVED`
- Added Prisma migration for the IVR template schema.
- Implemented CRUD APIs for IVR templates:
  - Create IVR template
  - Get all IVR templates
  - Get IVR template by ID
  - Update IVR template
  - Archive (soft delete) IVR template
- Added DTOs with request validation.
- Automatically updates the template status to `ACTIVE` when a `flowUrl` is provided during update.

## Notes

- Newly created IVR templates default to `DRAFT` status.
- Archiving is implemented as a soft delete by updating the status to `ARCHIVED`.
- Templates are automatically marked as `ACTIVE` once a `flowUrl` is associated with them.