### PR TITLE
fix: refactor getAllGroups method to return all the beneficiary group if no pagination is provided

### DIFF
--- a/apps/aa/src/beneficiary/beneficiary.service.ts
+++ b/apps/aa/src/beneficiary/beneficiary.service.ts
@@ -224,27 +224,41 @@ export class BeneficiaryService {
       ],
     };
 
-    const benfGroups = await paginate(
-      this.prisma.beneficiaryGroups,
-      {
-        where: {
-          ...where,
-        },
-        include: {
-          _count: {
-            select: {
-              beneficiaries: true,
-            },
+    const query = {
+      where,
+      include: {
+        _count: {
+          select: {
+            beneficiaries: true,
           },
-          tokensReserved: true,
         },
-        orderBy,
+        tokensReserved: true,
       },
-      {
+      orderBy,
+    };
+
+    let benfGroups;
+
+    if (page !== undefined && perPage !== undefined) {
+      benfGroups = await paginate(this.prisma.beneficiaryGroups, query, {
         page,
         perPage,
-      }
-    );
+      });
+    } else {
+      const data = await this.prisma.beneficiaryGroups.findMany(query);
+
+      benfGroups = {
+        data,
+        meta: {
+          total: data.length,
+          currentPage: 1,
+          perPage: data.length,
+          lastPage: 1,
+          prev: null,
+          next: null,
+        },
+      };
+    }
 
     this.logger.debug(
       `Fetched ${benfGroups.data.length} groups, forwarding to project service`

--- a/apps/aa/src/beneficiary/beneficiary.service.ts
+++ b/apps/aa/src/beneficiary/beneficiary.service.ts
@@ -179,7 +179,6 @@ export class BeneficiaryService {
       hasPayout,
       excludeGroupPurpose,
     } = dto;
-
     const orderBy: Record<string, 'asc' | 'desc'> = {};
     orderBy[sort] = order;
 
@@ -237,28 +236,21 @@ export class BeneficiaryService {
       orderBy,
     };
 
-    let benfGroups;
-
-    if (page !== undefined && perPage !== undefined) {
-      benfGroups = await paginate(this.prisma.beneficiaryGroups, query, {
-        page,
-        perPage,
-      });
-    } else {
+    if (page === undefined || perPage === undefined) {
       const data = await this.prisma.beneficiaryGroups.findMany(query);
 
-      benfGroups = {
+      return {
         data,
         meta: {
           total: data.length,
-          currentPage: 1,
-          perPage: data.length,
-          lastPage: 1,
-          prev: null,
-          next: null,
         },
       };
     }
+
+    const benfGroups = await paginate(this.prisma.beneficiaryGroups, query, {
+      page,
+      perPage,
+    });
 
     this.logger.debug(
       `Fetched ${benfGroups.data.length} groups, forwarding to project service`


### PR DESCRIPTION
###Description

Updated the beneficiary groups listing API to support optional pagination.

- Returns paginated results when page and perPage are provided.
- Returns all matching beneficiary groups when pagination parameters are omitted.
