### PR TITLE
feat(aa): add error codes for frontend translation support

### DIFF
--- a/apps/aa/src/beneficiary/beneficiary.multisig.service.ts
+++ b/apps/aa/src/beneficiary/beneficiary.multisig.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
 import SafeApiKit from '@safe-global/api-kit';
 import Safe from '@safe-global/protocol-kit';
 import { PrismaService } from '@rumsan/prisma';
@@ -56,9 +57,11 @@ export class BeneficiaryMultisigService {
     });
 
     if (!chainSettings || !safeProposerPrivateKeySetting || !safeApiKey) {
-      throw new Error(
-        'CHAIN_SETTINGS, SAFE_PROPOSER_PRIVATE_ADDRESS or SAFE_API_KEY may be missing'
-      );
+      throw new RpcException({
+        message:
+          'CHAIN_SETTINGS, SAFE_PROPOSER_PRIVATE_ADDRESS or SAFE_API_KEY may be missing',
+        code: 'MULTISIG_SETTINGS_MISSING',
+      });
     }
 
     const CHAIN_ID = chainSettings.value['chainId'];

--- a/apps/aa/src/beneficiary/beneficiary.service.ts
+++ b/apps/aa/src/beneficiary/beneficiary.service.ts
@@ -913,7 +913,10 @@ export class BeneficiaryService {
 
     const sdpSettings = await this.settingsService.getPublic('SDP_SETTINGS');
     if (!sdpSettings?.value) {
-      throw new Error('SDP_SETTINGS not found in settings table');
+      throw new RpcException({
+        message: 'SDP_SETTINGS not found in settings table',
+        code: 'SDP_SETTINGS_NOT_FOUND',
+      });
     }
 
     const config = sdpSettings.value as Record<string, string>;
@@ -1610,7 +1613,10 @@ export class BeneficiaryService {
           ? (error as any).response?.data || error.message
           : String(error);
       this.logger.error(`Error fetching balances: ${errData}`);
-      throw new Error('Failed to fetch balances');
+      throw new RpcException({
+        message: 'Failed to fetch balances',
+        code: 'FAILED_TO_FETCH_BALANCES',
+      });
     }
   }
 
@@ -1658,7 +1664,11 @@ export class BeneficiaryService {
     };
 
     const handler = actionHandlers[action];
-    if (!handler) throw new Error('Invalid action');
+    if (!handler)
+      throw new RpcException({
+        message: 'Invalid action',
+        code: 'INVALID_DB_TRANSACTION_ACTION',
+      });
 
     try {
       const message = await handler();
@@ -1669,7 +1679,11 @@ export class BeneficiaryService {
       this.logger.error(
         `Database transaction failed [${action}] txId=${aaDbTxId}: ${errMsg}`
       );
-      throw new Error(`Database transaction failed: ${errMsg}`);
+      throw new RpcException({
+        message: `Database transaction failed: ${errMsg}`,
+        code: 'DATABASE_TRANSACTION_FAILED',
+        params: { message: errMsg },
+      });
     }
   }
 
@@ -1690,7 +1704,12 @@ export class BeneficiaryService {
     const group = await this.prisma.beneficiaryGroups.findUnique({
       where: { uuid: groupUuid },
     });
-    if (!group) throw new Error(`Beneficiary group not found: ${groupUuid}`);
+    if (!group)
+      throw new RpcException({
+        message: `Beneficiary group not found: ${groupUuid}`,
+        code: 'BENEFICIARY_GROUP_NOT_FOUND_SYNC',
+        params: { groupUuid },
+      });
 
     const BCRYPT_ROUNDS = 8;
     const isDev = process.env.NODE_ENV !== 'production';

--- a/apps/aa/src/beneficiary/beneficiary.service.ts
+++ b/apps/aa/src/beneficiary/beneficiary.service.ts
@@ -315,9 +315,11 @@ export class BeneficiaryService {
       this.logger.error(
         `Error fetching beneficiary groups by uuids: ${errMsg}`
       );
-      throw new RpcException(
-        `Error while fetching beneficiary groups by uuids. ${errMsg}`
-      );
+      throw new RpcException({
+        message: `Error while fetching beneficiary groups by uuids. ${errMsg}`,
+        code: 'FAILED_TO_FETCH_BENEFICIARY_GROUPS_BY_UUIDS',
+        params: { message: errMsg },
+      });
     }
   }
 
@@ -469,7 +471,11 @@ export class BeneficiaryService {
       },
     });
 
-    if (!benfGroup) throw new RpcException('Beneficiary group not found.');
+    if (!benfGroup)
+      throw new RpcException({
+        message: 'Beneficiary group not found.',
+        code: 'BENEFICIARY_GROUP_NOT_FOUND',
+      });
 
     const data = await lastValueFrom(
       this.client.send(
@@ -616,6 +622,7 @@ export class BeneficiaryService {
         status: 'error',
         message:
           'Tokens have already been assigned to the following beneficiaries wallet addresses',
+        code: 'TOKENS_ALREADY_ASSIGNED',
         tokenAssignedBenfWallet,
         foundAssignedBenf,
         groupName: group.name,
@@ -655,7 +662,10 @@ export class BeneficiaryService {
       this.logger.warn(
         `Token already reserved for group: ${beneficiaryGroupId}`
       );
-      throw new RpcException('Token already reserved.');
+      throw new RpcException({
+        message: 'Token already reserved.',
+        code: 'TOKEN_ALREADY_RESERVED',
+      });
     }
 
     const benfGroup = await this.prisma.beneficiaryGroups.findUnique({
@@ -666,7 +676,10 @@ export class BeneficiaryService {
 
     if (!benfGroup) {
       this.logger.warn(`Beneficiary group not found: ${beneficiaryGroupId}`);
-      throw new RpcException('Beneficiary group not found.');
+      throw new RpcException({
+        message: 'Beneficiary group not found.',
+        code: 'BENEFICIARY_GROUP_NOT_FOUND',
+      });
     }
 
     const allowedPurposes: (GroupPurpose | null)[] = [
@@ -679,9 +692,11 @@ export class BeneficiaryService {
       this.logger.warn(
         `Invalid group purpose ${benfGroup.groupPurpose} for group: ${beneficiaryGroupId}`
       );
-      throw new RpcException(
-        `Invalid group purpose ${benfGroup.groupPurpose}. Allowed purposes: BANK_TRANSFER, MOBILE_MONEY, GENERAL.`
-      );
+      throw new RpcException({
+        message: `Invalid group purpose ${benfGroup.groupPurpose}. Allowed purposes: BANK_TRANSFER, MOBILE_MONEY, GENERAL.`,
+        code: 'INVALID_GROUP_PURPOSE_WITH_GENERAL',
+        params: { purpose: benfGroup.groupPurpose },
+      });
     }
 
     if (benfGroup.groupPurpose === GroupPurpose.GENERAL) {
@@ -692,11 +707,13 @@ export class BeneficiaryService {
         this.logger.warn(
           `Group purpose GENERAL not allowed for group: ${beneficiaryGroupId} with payout type: ${params?.type}, isPayoutIntegrated: ${isPayoutIntegrated}`
         );
-        throw new RpcException(
-          `Group purpose GENERAL is only allowed for VENDOR payouts. Received payout type: ${
+        throw new RpcException({
+          message: `Group purpose GENERAL is only allowed for VENDOR payouts. Received payout type: ${
             params?.type ?? 'none'
-          }, `
-        );
+          }, `,
+          code: 'GROUP_PURPOSE_GENERAL_ONLY_FOR_VENDOR_PAYOUTS',
+          params: { payoutType: params?.type ?? 'none' },
+        });
       }
     }
 
@@ -992,7 +1009,10 @@ export class BeneficiaryService {
       });
 
       if (!activeToken)
-        throw new RpcException('No active token found for group.');
+        throw new RpcException({
+          message: 'No active token found for group.',
+          code: 'NO_ACTIVE_TOKEN_FOUND_FOR_GROUP',
+        });
 
       const benfGroupToken = await this.prisma.beneficiaryGroupTokens.update({
         where: { uuid: activeToken.uuid },
@@ -1261,7 +1281,10 @@ export class BeneficiaryService {
     );
 
     if (!beneficiaryUUID) {
-      throw new RpcException('Beneficiary UUID is required');
+      throw new RpcException({
+        message: 'Beneficiary UUID is required',
+        code: 'BENEFICIARY_UUID_REQUIRED',
+      });
     }
 
     // First get the beneficiary to get their wallet address
@@ -1272,7 +1295,10 @@ export class BeneficiaryService {
 
     if (!beneficiary) {
       this.logger.warn(`Beneficiary not found: ${beneficiaryUUID}`);
-      throw new RpcException('Beneficiary not found');
+      throw new RpcException({
+        message: 'Beneficiary not found',
+        code: 'BENEFICIARY_NOT_FOUND',
+      });
     }
 
     try {
@@ -1349,7 +1375,10 @@ export class BeneficiaryService {
     );
 
     if (!beneficiaryUUID) {
-      throw new RpcException('Beneficiary UUID is required');
+      throw new RpcException({
+        message: 'Beneficiary UUID is required',
+        code: 'BENEFICIARY_UUID_REQUIRED',
+      });
     }
 
     // First get the beneficiary to get their wallet address
@@ -1360,7 +1389,10 @@ export class BeneficiaryService {
 
     if (!beneficiary) {
       this.logger.warn(`Beneficiary not found: ${beneficiaryUUID}`);
-      throw new RpcException('Beneficiary not found');
+      throw new RpcException({
+        message: 'Beneficiary not found',
+        code: 'BENEFICIARY_NOT_FOUND',
+      });
     }
 
     try {
@@ -1482,9 +1514,12 @@ export class BeneficiaryService {
       return;
     } catch (error) {
       this.logger.error(`Error updating beneficiary tokens: ${error}`);
-      throw new RpcException(
-        `Failed to update beneficiary tokens for group ${groupUuid}: ${error.message}`
-      );
+      const errMsg = error instanceof Error ? error.message : String(error);
+      throw new RpcException({
+        message: `Failed to update beneficiary tokens for group ${groupUuid}: ${errMsg}`,
+        code: 'FAILED_TO_UPDATE_BENEFICIARY_TOKENS',
+        params: { groupUuid, message: errMsg },
+      });
     }
   }
 

--- a/apps/aa/src/beneficiary/dto/get-group.dto.ts
+++ b/apps/aa/src/beneficiary/dto/get-group.dto.ts
@@ -68,12 +68,12 @@ export class GetBenfGroupDto {
 
 export class getGroupByUuidDto {
   @IsArray()
-  @ArrayNotEmpty({ message: 'uuids array cannot be empty' })
-  @IsString({ each: true, message: 'Each UUID must be a string' })
+  @ArrayNotEmpty({ message: '[UUIDS_ARRAY_CANNOT_BE_EMPTY] uuids array cannot be empty' })
+  @IsString({ each: true, message: '[UUID_MUST_BE_STRING] Each UUID must be a string' })
   uuids: string[];
 
   @IsArray()
-  @ArrayNotEmpty({ message: 'selectField array cannot be empty' })
-  @IsString({ each: true, message: 'Each field name must be a string' })
+  @ArrayNotEmpty({ message: '[SELECT_FIELD_ARRAY_CANNOT_BE_EMPTY] selectField array cannot be empty' })
+  @IsString({ each: true, message: '[FIELD_NAME_MUST_BE_STRING] Each field name must be a string' })
   selectField: string[];
 }

--- a/apps/aa/src/cash-tracker/cash-tracker.service.ts
+++ b/apps/aa/src/cash-tracker/cash-tracker.service.ts
@@ -217,12 +217,20 @@ export class CashTrackerService {
       const fromSDK = this.entitySDKs.get(from);
 
       if (!fromSDK) {
-        throw new Error(`Entity not found for smart address: ${from}`);
+        throw new RpcException({
+          message: `Entity not found for smart address: ${from}`,
+          code: 'CASH_TRACKER_ENTITY_NOT_FOUND',
+          params: { address: from },
+        });
       }
 
       // For actions that require both from and to, ensure 'to' is provided
       if (normalizedAction !== 'get_cash_balance' && !to) {
-        throw new Error(`Missing 'to' smart address for action: ${action}`);
+        throw new RpcException({
+          message: `Missing 'to' smart address for action: ${action}`,
+          code: 'CASH_TRACKER_MISSING_TO_ADDRESS',
+          params: { action },
+        });
       }
 
       // Validate action based on user roles (if roles are defined)
@@ -251,7 +259,11 @@ export class CashTrackerService {
           return this.serializeBigInt(balance);
 
         default:
-          throw new Error(`Unknown action: ${action}`);
+          throw new RpcException({
+            message: `Unknown action: ${action}`,
+            code: 'CASH_TRACKER_UNKNOWN_ACTION',
+            params: { action },
+          });
       }
 
       return this.serializeBigInt(result as TransactionResult);

--- a/apps/aa/src/cash-tracker/cash-tracker.service.ts
+++ b/apps/aa/src/cash-tracker/cash-tracker.service.ts
@@ -488,7 +488,11 @@ export class CashTrackerService {
       const result = await evmUtils.mintTokens(mintRequest, rahatDonorConfig);
 
       if (!result.success) {
-        throw new RpcException(`Mint operation failed: ${result.error}`);
+        throw new RpcException({
+          message: `Mint operation failed: ${result.error}`,
+          code: 'CASH_TRACKER_MINT_FAILED',
+          params: { error: result.error },
+        });
       }
 
       this.logger.log(
@@ -503,7 +507,11 @@ export class CashTrackerService {
       };
     } catch (error) {
       this.logger.error(`Failed to create budget: ${error.message}`);
-      throw new RpcException(`Budget creation failed: ${error.message}`);
+      throw new RpcException({
+        message: `Budget creation failed: ${error.message}`,
+        code: 'CASH_TRACKER_BUDGET_CREATE_FAILED',
+        params: { message: error.message },
+      });
     }
   }
 }

--- a/apps/aa/src/chain/chain-queue.service.ts
+++ b/apps/aa/src/chain/chain-queue.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
 import { ChainServiceRegistry } from './registries/chain-service.registry';
 import {
   IChainService,
@@ -29,9 +30,11 @@ export class ChainQueueService {
     );
 
     if (!chainService.addTrigger) {
-      throw new Error(
-        `Trigger functionality not supported for ${chainService.getChainType()} chain`
-      );
+      throw new RpcException({
+        message: `Trigger functionality not supported for ${chainService.getChainType()} chain`,
+        code: 'CHAIN_TRIGGER_UNSUPPORTED',
+        params: { chainType: chainService.getChainType() },
+      });
     }
 
     return chainService.getDisbursementStats(payload || {});
@@ -74,9 +77,11 @@ export class ChainQueueService {
     );
 
     if (!chainService.preDisburse) {
-      throw new Error(
-        `Disburse-on-create not supported for ${chainService.getChainType()} chain`
-      );
+      throw new RpcException({
+        message: `Disburse-on-create not supported for ${chainService.getChainType()} chain`,
+        code: 'CHAIN_DISBURSE_ON_CREATE_UNSUPPORTED',
+        params: { chainType: chainService.getChainType() },
+      });
     }
 
     return chainService.preDisburse(data);
@@ -180,9 +185,11 @@ export class ChainQueueService {
     );
 
     if (!chainService.addTrigger) {
-      throw new Error(
-        `Trigger functionality not supported for ${chainService.getChainType()} chain`
-      );
+      throw new RpcException({
+        message: `Trigger functionality not supported for ${chainService.getChainType()} chain`,
+        code: 'CHAIN_TRIGGER_UNSUPPORTED',
+        params: { chainType: chainService.getChainType() },
+      });
     }
 
     return chainService.addTrigger(data);
@@ -198,9 +205,11 @@ export class ChainQueueService {
     );
 
     if (!chainService.updateTrigger) {
-      throw new Error(
-        `Trigger update functionality not supported for ${chainService.getChainType()} chain`
-      );
+      throw new RpcException({
+        message: `Trigger update functionality not supported for ${chainService.getChainType()} chain`,
+        code: 'CHAIN_TRIGGER_UNSUPPORTED',
+        params: { chainType: chainService.getChainType() },
+      });
     }
 
     return chainService.updateTrigger(data);

--- a/apps/aa/src/chain/chain-services/evm-chain.service.ts
+++ b/apps/aa/src/chain/chain-services/evm-chain.service.ts
@@ -168,12 +168,18 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
   async addTrigger(data: AddTriggerDto): Promise<any> {
     // EVM triggers are not implemented yet - throw error for now
-    throw new Error('EVM triggers not implemented yet');
+    throw new RpcException({
+      message: 'EVM triggers not implemented yet',
+      code: 'EVM_TRIGGERS_NOT_IMPLEMENTED',
+    });
   }
 
   async updateTriggerParams(triggerUpdate: any): Promise<any> {
     // EVM triggers are not implemented yet - throw error for now
-    throw new Error('EVM triggers not implemented yet');
+    throw new RpcException({
+      message: 'EVM triggers not implemented yet',
+      code: 'EVM_TRIGGERS_NOT_IMPLEMENTED',
+    });
   }
 
   async addBeneficiary(beneficiaryAddress: string): Promise<any> {
@@ -335,11 +341,18 @@ export class EvmChainService implements IChainService, OnModuleInit {
   }
 
   async transferTokens(data: TransferTokensDto): Promise<any> {
-    throw new Error('Transfer tokens not implemented for EVM');
+    throw new RpcException({
+      message: 'Transfer tokens not implemented for EVM',
+      code: 'TRANSFER_TOKENS_NOT_IMPLEMENTED_FOR_EVM',
+    });
   }
 
   async preDisburse(_data: DisburseDto): Promise<any> {
-    throw new RpcException('Disburse-on-create not supported on EVM chain');
+    throw new RpcException({
+      message: 'Disburse-on-create not supported on EVM chain',
+      code: 'CHAIN_DISBURSE_ON_CREATE_UNSUPPORTED',
+      params: { chainType: 'EVM' },
+    });
   }
 
   async disburse(data: DisburseDto): Promise<any> {
@@ -740,17 +753,26 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
     if (!payoutType) {
       this.logger.error('Payout not initiated');
-      throw new RpcException('Payout not initiated');
+      throw new RpcException({
+        message: 'Payout not initiated',
+        code: 'PAYOUT_ERR_SEND_OTP_NOT_INITIATED',
+      });
     }
 
     if (payoutType.type != 'VENDOR') {
       this.logger.error('Payout type is not VENDOR');
-      throw new RpcException('Payout type is not VENDOR');
+      throw new RpcException({
+        message: 'Payout type is not VENDOR',
+        code: 'PAYOUT_ERR_SEND_OTP_TYPE_NOT_VENDOR',
+      });
     }
 
     if (payoutType.mode != 'ONLINE') {
       this.logger.error('Payout mode is not ONLINE');
-      throw new RpcException('Payout mode is not ONLINE');
+      throw new RpcException({
+        message: 'Payout mode is not ONLINE',
+        code: 'PAYOUT_ERR_SEND_OTP_MODE_NOT_ONLINE',
+      });
     }
 
     return this.sendOtpByPhone(sendOtpDto, payoutType.uuid);
@@ -765,7 +787,7 @@ export class EvmChainService implements IChainService, OnModuleInit {
       });
 
       if (!vendor) {
-        throw new RpcException('Vendor not found');
+        throw new RpcException({ message: 'Vendor not found', code: 'PAYOUT_ERR_VENDOR_NOT_FOUND' });
       }
 
       const amount = verifyOtpDto?.amount;
@@ -785,7 +807,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
       )) as any;
 
       if (!keys) {
-        throw new RpcException('Beneficiary address not found');
+        throw new RpcException({
+          message: 'Beneficiary address not found',
+          code: 'PAYOUT_ERR_BENEFICIARY_ADDRESS_NOT_FOUND',
+        });
       }
 
       console.log('keys', keys);
@@ -802,9 +827,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
           `Beneficiary ${keys.address} has no tokens in contract. Transfer denied.`,
           EvmChainService.name
         );
-        throw new RpcException(
-          'Beneficiary has no tokens available for transfer'
-        );
+        throw new RpcException({
+          message: 'Beneficiary has no tokens available for transfer',
+          code: 'BENEFICIARY_NO_TOKENS_AVAILABLE',
+        });
       }
 
       this.logger.log(
@@ -819,9 +845,11 @@ export class EvmChainService implements IChainService, OnModuleInit {
       );
 
       if (!result) {
-        throw new RpcException(
-          `Token transfer to ${verifyOtpDto.receiverAddress} failed`
-        );
+        throw new RpcException({
+          message: `Token transfer to ${verifyOtpDto.receiverAddress} failed`,
+          code: 'TOKEN_TRANSFER_TO_ADDRESS_FAILED',
+          params: { address: verifyOtpDto.receiverAddress },
+        });
       }
 
       this.logger.log(`Transfer successful: ${result.txHash}`);
@@ -840,7 +868,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
       });
 
       if (!existingRedeem) {
-        throw new RpcException('No pending BeneficiaryRedeem record found');
+        throw new RpcException({
+          message: 'No pending BeneficiaryRedeem record found',
+          code: 'NO_PENDING_BENEFICIARY_REDEEM_FOUND',
+        });
       }
 
       // Update the BeneficiaryRedeem record with transaction details
@@ -971,9 +1002,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
       const keys = await this.getSecretByPhone(data.phoneNumber);
 
       if (!keys || !keys.address) {
-        throw new RpcException(
-          'Beneficiary wallet not found for this phone number'
-        );
+        throw new RpcException({
+          message: 'Beneficiary wallet not found for this phone number',
+          code: 'BENEFICIARY_WALLET_NOT_FOUND_FOR_PHONE',
+        });
       }
 
       // Proceed with OTP verification
@@ -992,7 +1024,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
         error.stack,
         EvmChainService.name
       );
-      throw new RpcException(`OTP verification failed: ${error.message}`);
+      throw new RpcException({
+        message: `OTP verification failed: ${error.message}`,
+        code: 'STELLAR_ERR_OTP_VERIFY_FAILED',
+      });
     }
   }
 
@@ -1017,7 +1052,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
       );
 
       if (!resolvedData || !Array.isArray(resolvedData.beneficiaries)) {
-        throw new Error('Invalid group resolution response');
+        throw new RpcException({
+          message: 'Invalid group resolution response',
+          code: 'INVALID_GROUP_RESOLUTION_RESPONSE',
+        });
       }
 
       return {
@@ -1028,14 +1066,17 @@ export class EvmChainService implements IChainService, OnModuleInit {
           (b: any) => b.tokenAmount?.toString() || '0'
         ),
       };
-    } catch (error) {
+    } catch (error: any) {
       this.logger.error(
         `Error resolving groups: ${error.message}`,
         error.stack
       );
-      throw new Error(
-        `Failed to resolve groups to addresses: ${error.message}`
-      );
+      if (error instanceof RpcException) throw error;
+      throw new RpcException({
+        message: `Failed to resolve groups to addresses: ${error.message}`,
+        code: 'FAILED_TO_RESOLVE_GROUPS_TO_ADDRESSES',
+        params: { message: error.message },
+      });
     }
   }
 
@@ -1065,7 +1106,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
     try {
       const settings = await this.settingsService.getPublic('CHAIN_SETTINGS');
       if (!settings?.value) {
-        throw new Error('CHAIN_SETTINGS not found in settings');
+        throw new RpcException({
+          message: 'CHAIN_SETTINGS not found in settings',
+          code: 'CHAIN_SETTINGS_NOT_FOUND',
+        });
       }
 
       const config = settings.value as unknown as EVMChainConfig;
@@ -1075,7 +1119,11 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
       for (const field of requiredFields) {
         if (!config[field as keyof EVMChainConfig]) {
-          throw new Error(`Missing required field ${field} in CHAIN_SETTINGS`);
+          throw new RpcException({
+            message: `Missing required field ${field} in CHAIN_SETTINGS`,
+            code: 'MISSING_REQUIRED_FIELD_IN_CHAIN_SETTINGS',
+            params: { field },
+          });
         }
       }
       console.log(config);
@@ -1135,25 +1183,34 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
     if (!record) {
       this.logger.log('OTP record not found');
-      throw new RpcException('OTP record not found');
+      throw new RpcException({
+        message: 'OTP record not found',
+        code: 'OTP_RECORD_NOT_FOUND',
+      });
     }
 
     if (record.isVerified) {
       this.logger.log('OTP already verified');
-      throw new RpcException('OTP already verified');
+      throw new RpcException({
+        message: 'OTP already verified',
+        code: 'OTP_ALREADY_VERIFIED',
+      });
     }
 
     const now = new Date();
     if (record.expiresAt < now) {
       this.logger.log('OTP has expired');
-      throw new RpcException('OTP has expired');
+      throw new RpcException({ message: 'OTP has expired', code: 'OTP_EXPIRED' });
     }
 
     const isValid = await bcrypt.compare(`${otp}:${amount}`, record.otpHash);
 
     if (!isValid) {
       this.logger.log('Invalid OTP or amount mismatch');
-      throw new RpcException('Invalid OTP or amount mismatch');
+      throw new RpcException({
+        message: 'Invalid OTP or amount mismatch',
+        code: 'INVALID_OTP_OR_AMOUNT_MISMATCH',
+      });
     }
 
     this.logger.log('OTP verified successfully');
@@ -1190,7 +1247,11 @@ export class EvmChainService implements IChainService, OnModuleInit {
         `Couldn't find secret for phone ${phoneNumber}`,
         error.message
       );
-      throw new RpcException(`Beneficiary with phone ${phoneNumber} not found`);
+      throw new RpcException({
+        message: `Beneficiary with phone ${phoneNumber} not found`,
+        code: 'PAYOUT_ERR_BENEFICIARY_PHONE_NOT_FOUND',
+        params: { phoneNumber },
+      });
     }
   }
 
@@ -1276,13 +1337,13 @@ export class EvmChainService implements IChainService, OnModuleInit {
       },
     });
     if (!vendor) {
-      throw new RpcException('Vendor not found');
+      throw new RpcException({ message: 'Vendor not found', code: 'PAYOUT_ERR_VENDOR_NOT_FOUND' });
     }
 
     // Get beneficiary wallet address first
     const keys = await this.getSecretByPhone(sendOtpDto.phoneNumber);
     if (!keys) {
-      throw new RpcException('Beneficiary address not found');
+      throw new RpcException({ message: 'Beneficiary address not found', code: 'PAYOUT_ERR_BENEFICIARY_ADDRESS_NOT_FOUND' });
     }
 
     let beneficiaryTokenBalance: number;
@@ -1291,7 +1352,7 @@ export class EvmChainService implements IChainService, OnModuleInit {
     beneficiaryTokenBalance = Number(balanceData.balance);
 
     if (!beneficiaryTokenBalance) {
-      throw new RpcException('Beneficiary token balance not found');
+      throw new RpcException({ message: 'Beneficiary token balance not found', code: 'STELLAR_ERR_TOKEN_BALANCE_NOT_FOUND' });
     }
 
     this.logger.log(
@@ -1304,13 +1365,15 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
     // Validate amount
     if (Number(amount) > beneficiaryTokenBalance) {
-      throw new RpcException(
-        `Requested amount ${amount} is greater than available token balance ${beneficiaryTokenBalance}`
-      );
+      throw new RpcException({
+        message: `Requested amount ${amount} is greater than available token balance ${beneficiaryTokenBalance}`,
+        code: 'PAYOUT_ERR_AMOUNT_EXCEEDS_BALANCE',
+        params: { amount, balance: beneficiaryTokenBalance },
+      });
     }
 
     if (Number(amount) <= 0) {
-      throw new RpcException('Amount must be greater than 0');
+      throw new RpcException({ message: 'Amount must be greater than 0', code: 'PAYOUT_ERR_AMOUNT_NOT_POSITIVE' });
     }
 
     // Check if beneficiary has tokens in the contract before sending OTP
@@ -1323,9 +1386,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
         `Beneficiary ${keys.address} has no tokens in contract. OTP sending denied.`,
         EvmChainService.name
       );
-      throw new RpcException(
-        'Beneficiary has no tokens available for redemption'
-      );
+      throw new RpcException({
+        message: 'Beneficiary has no tokens available for redemption',
+        code: 'BENEFICIARY_NO_TOKENS_AVAILABLE',
+      });
     }
 
     this.logger.log(
@@ -1398,12 +1462,15 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
       if (!beneficiary) {
         this.logger.error('Beneficiary not found');
-        throw new RpcException('Beneficiary not found');
+        throw new RpcException({ message: 'Beneficiary not found', code: 'PAYOUT_ERR_BENEFICIARY_NOT_FOUND' });
       }
 
       if (!beneficiary.groupedBeneficiaries) {
         this.logger.error('Beneficiary has no grouped beneficiaries');
-        throw new RpcException('Beneficiary has no grouped beneficiaries');
+        throw new RpcException({
+          message: 'Beneficiary has no grouped beneficiaries',
+          code: 'BENEFICIARY_NO_GROUPED_BENEFICIARIES',
+        });
       }
 
       // Filter groupedBeneficiaries to only payout-eligible groups (not COMMUNICATION)
@@ -1413,9 +1480,10 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
       if (!payoutEligibleGroups.length) {
         this.logger.error('No payout-eligible group found for beneficiary');
-        throw new RpcException(
-          'No payout-eligible group found for beneficiary'
-        );
+        throw new RpcException({
+          message: 'No payout-eligible group found for beneficiary',
+          code: 'PAYOUT_ERR_NO_ELIGIBLE_GROUP',
+        });
       }
 
       if (payoutEligibleGroups.length > 1) {
@@ -1424,9 +1492,11 @@ export class EvmChainService implements IChainService, OnModuleInit {
             .map((g) => g.beneficiaryGroupId)
             .join(', ')}`
         );
-        throw new RpcException(
-          'Multiple payout-eligible groups found for beneficiary. Please contact support.'
-        );
+        throw new RpcException({
+          message:
+            'Multiple payout-eligible groups found for beneficiary. Please contact support.',
+          code: 'MULTIPLE_PAYOUT_ELIGIBLE_GROUPS_FOUND',
+        });
       }
 
       // Use the first payout-eligible group for the lookup
@@ -1447,7 +1517,7 @@ export class EvmChainService implements IChainService, OnModuleInit {
         this.logger.error(
           `Beneficiary group not found for ID: ${payoutEligibleGroups[0].beneficiaryGroupId}`
         );
-        throw new RpcException('Beneficiary group not found');
+        throw new RpcException({ message: 'Beneficiary group not found', code: 'PAYOUT_ERR_GROUP_NOT_FOUND' });
       }
 
       // Recheck, isDisbursed was false which was opposite of the needed logic, so changed to true to find the active token
@@ -1457,14 +1527,16 @@ export class EvmChainService implements IChainService, OnModuleInit {
 
       if (!activeToken) {
         this.logger.error('Tokens not reserved for the group');
-        throw new RpcException('Tokens not reserved for the group');
+        throw new RpcException({ message: 'Tokens not reserved for the group', code: 'PAYOUT_ERR_TOKENS_NOT_RESERVED' });
       }
 
       return activeToken.payout;
     } catch (error) {
-      throw new RpcException(
-        `Failed to retrieve payout type: ${error.message}`
-      );
+      throw new RpcException({
+        message: `Failed to retrieve payout type: ${error.message}`,
+        code: 'PAYOUT_ERR_RETRIEVE_TYPE',
+        params: { message: error.message },
+      });
     }
   }
 

--- a/apps/aa/src/chain/chain-services/stellar-chain.service.ts
+++ b/apps/aa/src/chain/chain-services/stellar-chain.service.ts
@@ -184,7 +184,10 @@ export class StellarChainService implements IChainService {
   async preDisburse(data: DisburseDto): Promise<any> {
     const groupUuid = data.groups?.[0];
     if (!groupUuid) {
-      throw new RpcException('preDisburse requires a single group uuid');
+      throw new RpcException({
+        message: 'preDisburse requires a single group uuid',
+        code: 'PRE_DISBURSE_REQUIRES_SINGLE_GROUP_UUID',
+      });
     }
 
     const disbursementSettings = await this.getDisbursementSettings();
@@ -469,7 +472,11 @@ export class StellarChainService implements IChainService {
   async getRahatTokenBalance(data: { address: string }): Promise<any> {
     this.logger.debug(`getRahatTokenBalance address=${data.address}`);
     if (!this.validateAddress(data.address)) {
-      throw new RpcException(`Invalid Stellar address: ${data.address}`);
+      throw new RpcException({
+        message: `Invalid Stellar address: ${data.address}`,
+        code: 'INVALID_STELLAR_ADDRESS',
+        params: { address: data.address },
+      });
     }
     const stellarSettings = await this.getFromSettings(
       'STELLAR_SPONSOR_SETTINGS'
@@ -510,9 +517,11 @@ export class StellarChainService implements IChainService {
       .map((ben) => {
         const amount = parseFloat(ben.amount);
         if (isNaN(amount) || amount < 1) {
-          throw new RpcException(
-            `Invalid amount for beneficiary ${ben.id}: must be >= 1`
-          );
+          throw new RpcException({
+            message: `Invalid amount for beneficiary ${ben.id}: must be >= 1`,
+            code: 'INVALID_AMOUNT_FOR_BENEFICIARY',
+            params: { id: ben.id },
+          });
         }
 
         const randomNumber = Math.floor(Math.random() * 100000);
@@ -540,11 +549,17 @@ export class StellarChainService implements IChainService {
   // --- Stub methods ---
 
   async assignTokens(_data: AssignTokensDto): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async transferTokens(_data: TransferTokensDto): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async sendOtp(data: SendOtpDto): Promise<any> {
@@ -557,17 +572,26 @@ export class StellarChainService implements IChainService {
 
     if (!payoutType) {
       this.logger.error('Payout not initiated');
-      throw new RpcException('Payout not initiated');
+      throw new RpcException({
+        message: 'Payout not initiated',
+        code: 'PAYOUT_ERR_SEND_OTP_NOT_INITIATED',
+      });
     }
 
     if (payoutType.type !== 'VENDOR') {
       this.logger.error('Payout type is not VENDOR');
-      throw new RpcException('Payout type is not VENDOR');
+      throw new RpcException({
+        message: 'Payout type is not VENDOR',
+        code: 'PAYOUT_ERR_SEND_OTP_TYPE_NOT_VENDOR',
+      });
     }
 
     if (payoutType.mode !== 'ONLINE') {
       this.logger.error('Payout mode is not ONLINE');
-      throw new RpcException('Payout mode is not ONLINE');
+      throw new RpcException({
+        message: 'Payout mode is not ONLINE',
+        code: 'PAYOUT_ERR_SEND_OTP_MODE_NOT_ONLINE',
+      });
     }
 
     return this.sendOtpByPhone(data, payoutType.uuid);
@@ -577,7 +601,11 @@ export class StellarChainService implements IChainService {
     const vendor = await this.prisma.vendor.findUnique({
       where: { walletAddress: data.receiverAddress },
     });
-    if (!vendor) throw new RpcException('Vendor not found');
+    if (!vendor)
+      throw new RpcException({
+        message: 'Vendor not found',
+        code: 'PAYOUT_ERR_VENDOR_NOT_FOUND',
+      });
 
     const amount = data.amount;
     await this.verifyOTP(data.otp, data.phoneNumber, amount as number);
@@ -587,7 +615,10 @@ export class StellarChainService implements IChainService {
       privateKey: string;
     } | null;
     if (!keys?.privateKey)
-      throw new RpcException('Beneficiary secret not found');
+      throw new RpcException({
+        message: 'Beneficiary secret not found',
+        code: 'BENEFICIARY_SECRET_NOT_FOUND',
+      });
 
     if (data.mediaUrl) {
       const existingRedeem = await this.prisma.beneficiaryRedeem.findFirst({
@@ -653,7 +684,10 @@ export class StellarChainService implements IChainService {
       privateKey: string;
     } | null;
     if (!keys?.privateKey)
-      throw new RpcException('Beneficiary secret not found');
+      throw new RpcException({
+        message: 'Beneficiary secret not found',
+        code: 'BENEFICIARY_SECRET_NOT_FOUND',
+      });
 
     const walletAddress = keys.address;
 
@@ -668,7 +702,10 @@ export class StellarChainService implements IChainService {
     });
 
     if (!existingRedeem)
-      throw new RpcException('No pending BeneficiaryRedeem record found');
+      throw new RpcException({
+        message: 'No pending BeneficiaryRedeem record found',
+        code: 'NO_PENDING_BENEFICIARY_REDEEM_FOUND',
+      });
 
     try {
       const stellarSettings = await this.getFromSettings(
@@ -686,9 +723,10 @@ export class StellarChainService implements IChainService {
       );
 
       if (parseFloat(tokenBalance) <= 0) {
-        throw new RpcException(
-          'Beneficiary has no tokens available for transfer'
-        );
+        throw new RpcException({
+          message: 'Beneficiary has no tokens available for transfer',
+          code: 'BENEFICIARY_NO_TOKENS_AVAILABLE',
+        });
       }
 
       const result = await stellarClient.sendFromSponsored(
@@ -783,27 +821,45 @@ export class StellarChainService implements IChainService {
   }
 
   async fundAccount(_data: FundAccountDto): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async checkBalance(_address: string): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async verifyOtp(_data: VerifyOtpDto): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async getDisbursementStatus(_id: string): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async addTrigger(_data: AddTriggerDto): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async updateTrigger(_data: UpdateTriggerDto): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   async redeemInkind(_data: RedeemInkindDto): Promise<any> {
@@ -837,7 +893,10 @@ export class StellarChainService implements IChainService {
   async redeemVendorInkindTokens(
     _data: RedeemInkindTokenForCashDto
   ): Promise<any> {
-    throw new RpcException('Not supported on Stellar SDP chain');
+    throw new RpcException({
+      message: 'Not supported on Stellar SDP chain',
+      code: 'NOT_SUPPORTED_ON_STELLAR_SDP',
+    });
   }
 
   // --- Private helpers ---
@@ -955,19 +1014,27 @@ export class StellarChainService implements IChainService {
       this.logger.log(`Beneficiary found: ${ben.address}`);
       return ben;
     } catch {
-      throw new RpcException(`Beneficiary with phone ${phoneNumber} not found`);
+      throw new RpcException({
+        message: `Beneficiary with phone ${phoneNumber} not found`,
+        code: 'PAYOUT_ERR_BENEFICIARY_PHONE_NOT_FOUND',
+        params: { phoneNumber },
+      });
     }
   }
 
   private async verifyOTP(otp: string, phoneNumber: string, amount: number) {
     const record = await this.prisma.otp.findUnique({ where: { phoneNumber } });
-    if (!record) throw new RpcException('OTP record not found');
-    if (record.isVerified) throw new RpcException('OTP already verified');
+    if (!record)
+      throw new RpcException({
+        message: 'OTP record not found',
+        code: 'OTP_RECORD_NOT_FOUND',
+      });
+    if (record.isVerified) throw new RpcException({ message: 'OTP already verified', code: 'OTP_ALREADY_VERIFIED' });
     if (record.expiresAt < new Date())
-      throw new RpcException('OTP has expired');
+      throw new RpcException({ message: 'OTP has expired', code: 'OTP_EXPIRED' });
 
     const isValid = await bcrypt.compare(`${otp}:${amount}`, record.otpHash);
-    if (!isValid) throw new RpcException('Invalid OTP or amount mismatch');
+    if (!isValid) throw new RpcException({ message: 'Invalid OTP or amount mismatch', code: 'INVALID_OTP_OR_AMOUNT_MISMATCH' });
 
     await this.prisma.otp.update({
       where: { phoneNumber },
@@ -1005,20 +1072,31 @@ export class StellarChainService implements IChainService {
       )
     );
 
-    if (!beneficiary) throw new RpcException('Beneficiary not found');
+    if (!beneficiary)
+      throw new RpcException({
+        message: 'Beneficiary not found',
+        code: 'PAYOUT_ERR_BENEFICIARY_NOT_FOUND',
+      });
     if (!beneficiary.groupedBeneficiaries)
-      throw new RpcException('Beneficiary has no grouped beneficiaries');
+      throw new RpcException({
+        message: 'Beneficiary has no grouped beneficiaries',
+        code: 'BENEFICIARY_NO_GROUPED_BENEFICIARIES',
+      });
 
     const payoutEligibleGroups = beneficiary.groupedBeneficiaries.filter(
       (g: any) => g.groupPurpose !== 'COMMUNICATION'
     );
 
     if (!payoutEligibleGroups.length)
-      throw new RpcException('No payout-eligible group found for beneficiary');
+      throw new RpcException({
+        message: 'No payout-eligible group found for beneficiary',
+        code: 'PAYOUT_ERR_NO_ELIGIBLE_GROUP',
+      });
     if (payoutEligibleGroups.length > 1)
-      throw new RpcException(
-        'Multiple payout-eligible groups found for beneficiary'
-      );
+      throw new RpcException({
+        message: 'Multiple payout-eligible groups found for beneficiary',
+        code: 'MULTIPLE_PAYOUT_ELIGIBLE_GROUPS_FOUND',
+      });
 
     const beneficiaryGroups = await this.prisma.beneficiaryGroups.findUnique({
       where: { uuid: payoutEligibleGroups[0].beneficiaryGroupId },
@@ -1026,7 +1104,10 @@ export class StellarChainService implements IChainService {
     });
 
     if (!beneficiaryGroups)
-      throw new RpcException('Beneficiary group not found');
+      throw new RpcException({
+        message: 'Beneficiary group not found',
+        code: 'PAYOUT_ERR_GROUP_NOT_FOUND',
+      });
 
     this.logger.log(
       `Found beneficiary group ${beneficiaryGroups.uuid} for phone ${phone}`
@@ -1035,7 +1116,10 @@ export class StellarChainService implements IChainService {
       `Beneficiary group details: ${JSON.stringify(beneficiaryGroups)}`
     );
     if (!beneficiaryGroups.tokensReserved)
-      throw new RpcException('Tokens not reserved for the group');
+      throw new RpcException({
+        message: 'Tokens not reserved for the group',
+        code: 'PAYOUT_ERR_TOKENS_NOT_RESERVED',
+      });
 
     const activeToken = beneficiaryGroups.tokensReserved.find(
       (t) => t.isDisbursed === true && t.payout?.status !== 'COMPLETED'
@@ -1043,7 +1127,10 @@ export class StellarChainService implements IChainService {
 
     if (!activeToken) {
       this.logger.error('No active payout found for the group');
-      throw new RpcException('No active payout found for the group');
+      throw new RpcException({
+        message: 'No active payout found for the group',
+        code: 'NO_ACTIVE_PAYOUT_FOUND_FOR_GROUP',
+      });
     }
 
     return activeToken.payout;
@@ -1053,10 +1140,18 @@ export class StellarChainService implements IChainService {
     const vendor = await this.prisma.vendor.findUnique({
       where: { uuid: data.vendorUuid },
     });
-    if (!vendor) throw new RpcException('Vendor not found');
+    if (!vendor)
+      throw new RpcException({
+        message: 'Vendor not found',
+        code: 'PAYOUT_ERR_VENDOR_NOT_FOUND',
+      });
 
     const keys = (await this.getSecretByPhone(data.phoneNumber)) as any;
-    if (!keys) throw new RpcException('Beneficiary address not found');
+    if (!keys)
+      throw new RpcException({
+        message: 'Beneficiary address not found',
+        code: 'PAYOUT_ERR_BENEFICIARY_ADDRESS_NOT_FOUND',
+      });
 
     const stellarSettings = await this.getFromSettings(
       'STELLAR_SPONSOR_SETTINGS'
@@ -1074,15 +1169,23 @@ export class StellarChainService implements IChainService {
 
     const beneficiaryTokenBalance = parseFloat(tokenBalance);
     if (!beneficiaryTokenBalance)
-      throw new RpcException('Beneficiary token balance not found');
+      throw new RpcException({
+        message: 'Beneficiary token balance not found',
+        code: 'STELLAR_ERR_TOKEN_BALANCE_NOT_FOUND',
+      });
 
     const amount = data.amount || beneficiaryTokenBalance;
     if (Number(amount) > beneficiaryTokenBalance)
-      throw new RpcException(
-        `Requested amount ${amount} exceeds available balance ${beneficiaryTokenBalance}`
-      );
+      throw new RpcException({
+        message: `Requested amount ${amount} exceeds available balance ${beneficiaryTokenBalance}`,
+        code: 'PAYOUT_ERR_AMOUNT_EXCEEDS_BALANCE',
+        params: { amount, balance: beneficiaryTokenBalance },
+      });
     if (Number(amount) <= 0)
-      throw new RpcException('Amount must be greater than 0');
+      throw new RpcException({
+        message: 'Amount must be greater than 0',
+        code: 'PAYOUT_ERR_AMOUNT_NOT_POSITIVE',
+      });
 
     const res = await lastValueFrom(
       this.client.send(

--- a/apps/aa/src/chain/chain-services/stellar-chain.service.ts
+++ b/apps/aa/src/chain/chain-services/stellar-chain.service.ts
@@ -886,7 +886,11 @@ export class StellarChainService implements IChainService {
       this.logger.error(
         `Error redeeming in-kind for beneficiary ${_data.beneficiaryAddress}: ${err.message}`
       );
-      throw new RpcException(`Error redeeming in-kind: ${err.message}`);
+      throw new RpcException({
+        message: `Error redeeming in-kind: ${err.message}`,
+        code: 'ERROR_REDEEMING_INKIND',
+        params: { message: err.message },
+      });
     }
   }
 

--- a/apps/aa/src/chain/registries/chain-service.registry.ts
+++ b/apps/aa/src/chain/registries/chain-service.registry.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
 import { SettingsService } from '@rumsan/settings';
 import {
   IChainService,
@@ -31,7 +32,11 @@ export class ChainServiceRegistry {
 
     const service = this.chainServices.get(detectedChain);
     if (!service) {
-      throw new Error(`Chain service not found for type: ${detectedChain}`);
+      throw new RpcException({
+        message: `Chain service not found for type: ${detectedChain}`,
+        code: 'CHAIN_SERVICE_NOT_FOUND',
+        params: { detectedChain },
+      });
     }
 
     return service;

--- a/apps/aa/src/comms/comms.service.ts
+++ b/apps/aa/src/comms/comms.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { ClientProxy } from '@nestjs/microservices';
+import { ClientProxy, RpcException } from '@nestjs/microservices';
 import { lastValueFrom, timeout } from 'rxjs';
 import { getClient } from '@rumsan/connect/src/clients';
 import * as nodemailer from 'nodemailer';
@@ -46,7 +46,10 @@ export class CommsService {
       );
 
       if (!communicationSettings) {
-        throw new Error('Communication settings not found in response');
+        throw new RpcException({
+          message: 'Communication settings not found in response',
+          code: 'COMMUNICATION_SETTINGS_NOT_FOUND',
+        });
       }
 
       this.client = getClient({
@@ -105,14 +108,20 @@ export class CommsService {
 
   get broadcast() {
     if (!this.client) {
-      throw new Error('Comms client is not available. Service is still initializing.');
+      throw new RpcException({
+        message: 'Comms client is not available. Service is still initializing.',
+        code: 'COMMS_CLIENT_NOT_AVAILABLE',
+      });
     }
     return this.client.broadcast;
   }
 
   get apiClient() {
     if (!this.client) {
-      throw new Error('Comms client is not available. Service is still initializing.');
+      throw new RpcException({
+        message: 'Comms client is not available. Service is still initializing.',
+        code: 'COMMS_CLIENT_NOT_AVAILABLE',
+      });
     }
     return this.client.apiClient;
   }
@@ -120,7 +129,10 @@ export class CommsService {
   async listTransports(): Promise<any> {
     const commsClient = await this.getClient();
     if (!commsClient) {
-      throw new Error('Comms client is not available. Service is still initializing.');
+      throw new RpcException({
+        message: 'Comms client is not available. Service is still initializing.',
+        code: 'COMMS_CLIENT_NOT_AVAILABLE',
+      });
     }
     const { data } = await commsClient.transport.list();
     
@@ -133,7 +145,10 @@ export class CommsService {
       (item: any) => item.name === 'EMAIL' && item.type === 'SMTP'
     );
     if (!emailTransport) {
-      throw new Error('No EMAIL/SMTP transport found');
+      throw new RpcException({
+        message: 'No EMAIL/SMTP transport found',
+        code: 'NO_EMAIL_SMTP_TRANSPORT_FOUND',
+      });
     }
     return emailTransport.cuid;
   }

--- a/apps/aa/src/grievances/dto/create-grievance.dto.ts
+++ b/apps/aa/src/grievances/dto/create-grievance.dto.ts
@@ -68,7 +68,8 @@ export class CreateGrievanceDto {
   @IsString()
   @IsNotEmpty()
   @IsEmailOrPhoneNumber({
-    message: 'reporterContact must be a valid email or phone number',
+    message:
+      '[REPORTER_CONTACT_INVALID] reporterContact must be a valid email or phone number',
   })
   reporterContact: string;
 
@@ -81,10 +82,10 @@ export class CreateGrievanceDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(5, {
-    message: 'Title must be at least 5 characters long',
+    message: '[TITLE_TOO_SHORT] Title must be at least 5 characters long',
   })
   @MaxLength(100, {
-    message: 'Title must not be longer than 100 characters',
+    message: '[TITLE_TOO_LONG] Title must not be longer than 100 characters',
   })
   title: string;
 
@@ -106,10 +107,12 @@ export class CreateGrievanceDto {
   @IsString()
   @IsNotEmpty()
   @MinLength(10, {
-    message: 'Description must be at least 10 characters long',
+    message:
+      '[DESCRIPTION_TOO_SHORT] Description must be at least 10 characters long',
   })
   @MaxLength(1000, {
-    message: 'Description must not be longer than 1000 characters',
+    message:
+      '[DESCRIPTION_TOO_LONG] Description must not be longer than 1000 characters',
   })
   description: string;
 

--- a/apps/aa/src/grievances/grievances.service.ts
+++ b/apps/aa/src/grievances/grievances.service.ts
@@ -120,7 +120,11 @@ export class GrievancesService {
       where: { uuid },
     });
     if (!existingGrievance) {
-      throw new RpcException('Grievance not found');
+      throw new RpcException({
+        message: 'Grievance not found',
+        code: 'GRIEVANCE_NOT_FOUND',
+        params: { uuid },
+      });
     }
 
     return this.prisma.$transaction(async (tx) => {
@@ -191,7 +195,11 @@ export class GrievancesService {
       where: { uuid },
     });
     if (!existingGrievance) {
-      throw new RpcException('Grievance not found');
+      throw new RpcException({
+        message: 'Grievance not found',
+        code: 'GRIEVANCE_NOT_FOUND',
+        params: { uuid },
+      });
     }
 
     return this.prisma.$transaction(async (tx) => {

--- a/apps/aa/src/grievances/utils/grievances.controller.utils.ts
+++ b/apps/aa/src/grievances/utils/grievances.controller.utils.ts
@@ -1,22 +1,30 @@
 import { RpcException } from '@nestjs/microservices';
 import { ValidationError } from 'class-validator';
 
-// Custom exception factory for validation errors
+// Custom exception factory for validation errors.
+// `message` must stay a flat string — RpcException's `.message` getter
+// returns whatever is passed as `error.message` verbatim, and the rest of
+// this codebase (and the frontend's translation resolvers) assumes that's
+// always a string. The first failing constraint's message is used as the
+// translatable summary (it's bracket-prefixed with a stable code in the DTO
+// decorators, e.g. "[TITLE_TOO_SHORT] Title must be..."); the full list of
+// per-field errors still travels in `errors` for anything that wants detail.
 export const validationExceptionFactory = (
   errors: ValidationError[]
 ): RpcException => {
   console.log('errors', errors);
-  const formattedErrors = {
-    message: 'Validation Error',
+  const flatMessages = errors.flatMap((error) =>
+    Object.values(error.constraints || {})
+  );
+  const primaryMessage = flatMessages[0] || 'Validation Error';
+
+  return new RpcException({
+    statusCode: 400,
+    message: primaryMessage,
     errors: errors.map((error) => ({
       property: error.property,
       constraints: error.constraints,
       value: error.value,
     })),
-  };
-
-  return new RpcException({
-    statusCode: 400,
-    message: formattedErrors,
   });
 };

--- a/apps/aa/src/group-cash-transfer/dto/group-cash-transfer.dto.ts
+++ b/apps/aa/src/group-cash-transfer/dto/group-cash-transfer.dto.ts
@@ -2,7 +2,7 @@ import { IsString, IsOptional, IsNumber, IsObject, IsUUID, IsBoolean, IsArray } 
 import { UserObject } from '../../inkinds';
 
 export class CreateGroupCashTransferDto {
-  @IsString()
+  @IsString({ message: '[GCT_NAME_MUST_BE_STRING] name must be a string' })
   name!: string;
 
   @IsOptional()
@@ -19,7 +19,7 @@ export class CreateGroupCashTransferDto {
 }
 
 export class UpdateGroupCashTransferDto {
-  @IsUUID()
+  @IsUUID(undefined, { message: '[GCT_UUID_MUST_BE_VALID] uuid must be a valid UUID' })
   uuid!: string;
 
   @IsOptional()
@@ -76,13 +76,13 @@ export class ListGroupCashTransferDto {
 }
 
 export class AssignFundDto {
-  @IsUUID()
+  @IsUUID(undefined, { message: '[GCT_GROUP_ID_MUST_BE_VALID] groupCashTransferId must be a valid UUID' })
   groupCashTransferId!: string;
 
-  @IsString()
+  @IsString({ message: '[GCT_FUND_TITLE_MUST_BE_STRING] title must be a string' })
   title!: string;
 
-  @IsNumber()
+  @IsNumber({}, { message: '[GCT_AMOUNT_MUST_BE_NUMBER] amount must be a number' })
   amount!: number;
 
     @IsObject()
@@ -90,7 +90,7 @@ export class AssignFundDto {
 }
 
 export class UpdateGroupCashTransferRecordDto {
-  @IsUUID()
+  @IsUUID(undefined, { message: '[GCT_UUID_MUST_BE_VALID] uuid must be a valid UUID' })
   uuid!: string;
 
   @IsOptional()

--- a/apps/aa/src/group-cash-transfer/gct-offramp.client.ts
+++ b/apps/aa/src/group-cash-transfer/gct-offramp.client.ts
@@ -16,7 +16,10 @@ export class GctOfframpClient {
     const accessToken = offrampSettings?.value?.accesstoken as string;
 
     if (!url || !appId || !accessToken) {
-      throw new RpcException('Offramp url/AppId/AccessToken not found in settings.');
+      throw new RpcException({
+        message: 'Offramp url/AppId/AccessToken not found in settings.',
+        code: 'OFFRAMP_SETTINGS_MISSING',
+      });
     }
 
     return { url, appId, accessToken };
@@ -33,7 +36,11 @@ export class GctOfframpClient {
       return data.wallet;
     } catch (error: any) {
       this.logger.error(`Failed to fetch offramp wallet address: ${error.message}`);
-      throw new RpcException(`Failed to fetch offramp wallet address: ${error.message}`);
+      throw new RpcException({
+        message: `Failed to fetch offramp wallet address: ${error.message}`,
+        code: 'FAILED_TO_FETCH_OFFRAMP_WALLET',
+        params: { message: error.message },
+      });
     }
   }
 
@@ -50,9 +57,12 @@ export class GctOfframpClient {
       
       return data;
     } catch (error: any) {
-      throw new RpcException(
-        `Failed to validate bank account: ${error?.response?.data?.message || error?.message}`
-      );
+      const detailMessage = error?.response?.data?.message || error?.message;
+      throw new RpcException({
+        message: `Failed to validate bank account: ${detailMessage}`,
+        code: 'FAILED_TO_VALIDATE_BANK_ACCOUNT',
+        params: { message: detailMessage },
+      });
     }
   }
 
@@ -66,9 +76,12 @@ export class GctOfframpClient {
       });
       return data;
     } catch (error: any) {
-      throw new RpcException(
-        `Failed to initiate instant offramp: ${error?.response?.data?.message || error?.message}`
-      );
+      const detailMessage = error?.response?.data?.message || error?.message;
+      throw new RpcException({
+        message: `Failed to initiate instant offramp: ${detailMessage}`,
+        code: 'FAILED_TO_INITIATE_INSTANT_OFFRAMP',
+        params: { message: detailMessage },
+      });
     }
   }
 
@@ -82,9 +95,12 @@ export class GctOfframpClient {
       });
       return data;
     } catch (error: any) {
-      throw new RpcException(
-        `Failed to initiate instant offramp v2: ${error?.response?.data?.message || error?.message}`
-      );
+      const detailMessage = error?.response?.data?.message || error?.message;
+      throw new RpcException({
+        message: `Failed to initiate instant offramp v2: ${detailMessage}`,
+        code: 'FAILED_TO_INITIATE_INSTANT_OFFRAMP_V2',
+        params: { message: detailMessage },
+      });
     }
   }
 }

--- a/apps/aa/src/group-cash-transfer/gct-treasury.service.ts
+++ b/apps/aa/src/group-cash-transfer/gct-treasury.service.ts
@@ -98,9 +98,11 @@ export class GctTreasuryService implements OnModuleInit {
 
   private assertConfigured() {
     if (this.misconfigured) {
-      throw new RpcException(
-        'GCT treasury is misconfigured: GCT_PUBLIC_KEY does not match the active chain. Fix CHAIN_SETTINGS/GCT_TREASURY before disbursing.'
-      );
+      throw new RpcException({
+        message:
+          'GCT treasury is misconfigured: GCT_PUBLIC_KEY does not match the active chain. Fix CHAIN_SETTINGS/GCT_TREASURY before disbursing.',
+        code: 'GCT_TREASURY_MISCONFIGURED',
+      });
     }
   }
 
@@ -114,7 +116,10 @@ export class GctTreasuryService implements OnModuleInit {
     const chainSettings = await this.appService.getSettings({ name: 'CHAIN_SETTINGS' });
     const rpcUrl = (chainSettings?.value as any)?.rpcurl;
     if (!rpcUrl) {
-      throw new RpcException('CHAIN_SETTINGS.rpcUrl not found');
+      throw new RpcException({
+        message: 'CHAIN_SETTINGS.rpcUrl not found',
+        code: 'CHAIN_RPC_URL_NOT_FOUND',
+      });
     }
     return rpcUrl;
   }
@@ -131,7 +136,10 @@ export class GctTreasuryService implements OnModuleInit {
     const gctPublicKey = value?.gct_public_key;
 
     if (!gctToken || !gctSecretKey || !gctPublicKey) {
-      throw new RpcException('GCT_TREASURY setting is missing GCT_TOKEN/GCT_SECRET_KEY/GCT_PUBLIC_KEY');
+      throw new RpcException({
+        message: 'GCT_TREASURY setting is missing GCT_TOKEN/GCT_SECRET_KEY/GCT_PUBLIC_KEY',
+        code: 'GCT_TREASURY_SETTING_MISSING',
+      });
     }
 
     return { gctToken, gctSecretKey, gctPublicKey };
@@ -146,7 +154,10 @@ export class GctTreasuryService implements OnModuleInit {
   private parseStellarAsset(gctToken: string): { assetCode: string; assetIssuer: string } {
     const [assetCode, assetIssuer] = gctToken.split(':');
     if (!assetCode || !assetIssuer) {
-      throw new RpcException('GCT_TOKEN must be in "<asset_code>:<asset_issuer>" format for stellar');
+      throw new RpcException({
+        message: 'GCT_TOKEN must be in "<asset_code>:<asset_issuer>" format for stellar',
+        code: 'GCT_TOKEN_FORMAT_INVALID',
+      });
     }
     return { assetCode, assetIssuer };
   }

--- a/apps/aa/src/group-cash-transfer/group-cash-transfer.service.ts
+++ b/apps/aa/src/group-cash-transfer/group-cash-transfer.service.ts
@@ -54,6 +54,7 @@ export class GroupCashTransferService {
         `Failed to create group cash transfer: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -97,6 +98,7 @@ export class GroupCashTransferService {
         `Failed to update group cash transfer: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -111,9 +113,10 @@ export class GroupCashTransferService {
       });
 
       if (fundCount > 0) {
-        throw new RpcException(
-          'Cannot delete: fund has already been assigned to this group'
-        );
+        throw new RpcException({
+          message: 'Cannot delete: fund has already been assigned to this group',
+          code: 'CANNOT_DELETE_FUND_ALREADY_ASSIGNED',
+        });
       }
 
       await this.db.groupCashTransferDetail.update({
@@ -131,6 +134,7 @@ export class GroupCashTransferService {
         `Failed to delete group cash transfer: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -236,6 +240,7 @@ export class GroupCashTransferService {
         `Failed to fetch group cash transfers: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -264,9 +269,11 @@ export class GroupCashTransferService {
       });
 
       if (!record) {
-        throw new RpcException(
-          `Group cash transfer with UUID ${uuid} not found`
-        );
+        throw new RpcException({
+          message: `Group cash transfer with UUID ${uuid} not found`,
+          code: 'GCT_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       const totalAmount = record.groupCashTransferRecords.reduce(
@@ -306,9 +313,11 @@ export class GroupCashTransferService {
       // }
 
       if (!gctDetail.extras.isBankValidated) {
-        throw new RpcException(
-          'Bank account for this group has not been validated. Please validate the bank account before assigning funds.'
-        );
+        throw new RpcException({
+          message:
+            'Bank account for this group has not been validated. Please validate the bank account before assigning funds.',
+          code: 'BANK_NOT_VALIDATED_BEFORE_ASSIGN',
+        });
       }
 
       const record = await this.db.groupCashTransferRecord.create({
@@ -325,6 +334,7 @@ export class GroupCashTransferService {
       return record;
     } catch (error: any) {
       this.logger.error(`Failed to assign fund: ${error.message}`, error.stack);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -354,9 +364,11 @@ export class GroupCashTransferService {
           },
         });
         if (!group) {
-          throw new RpcException(
-            `Group cash transfer '${groupCashTransferName}' not found`
-          );
+          throw new RpcException({
+            message: `Group cash transfer '${groupCashTransferName}' not found`,
+            code: 'GROUP_CASH_TRANSFER_NAME_NOT_FOUND',
+            params: { name: groupCashTransferName },
+          });
         }
         groupCashTransferId = group.uuid;
       }
@@ -399,6 +411,7 @@ export class GroupCashTransferService {
         `Failed to fetch records: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -417,9 +430,11 @@ export class GroupCashTransferService {
       });
 
       if (!record) {
-        throw new RpcException(
-          `Group cash transfer record ${recordUuid} not found`
-        );
+        throw new RpcException({
+          message: `Group cash transfer record ${recordUuid} not found`,
+          code: 'GCT_RECORD_NOT_FOUND',
+          params: { recordUuid },
+        });
       }
 
       return record;
@@ -442,20 +457,28 @@ export class GroupCashTransferService {
       });
 
       if (!record) {
-        throw new RpcException(`Record ${uuid} not found`);
+        throw new RpcException({
+          message: `Record ${uuid} not found`,
+          code: 'RECORD_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       if (record.disbursedAt) {
-        throw new RpcException(
-          'Cannot edit: disbursal has already been initiated for this record'
-        );
+        throw new RpcException({
+          message:
+            'Cannot edit: disbursal has already been initiated for this record',
+          code: 'CANNOT_EDIT_DISBURSAL_INITIATED',
+        });
       }
 
       const editableStatuses = ['NOT_STARTED', 'FAILED'];
       if (!editableStatuses.includes(record.status)) {
-        throw new RpcException(
-          `Cannot edit: record status is '${record.status}'. Only NOT_STARTED or FAILED records can be edited`
-        );
+        throw new RpcException({
+          message: `Cannot edit: record status is '${record.status}'. Only NOT_STARTED or FAILED records can be edited`,
+          code: 'CANNOT_EDIT_RECORD_STATUS',
+          params: { status: record.status },
+        });
       }
 
       return this.db.groupCashTransferRecord.update({
@@ -467,13 +490,17 @@ export class GroupCashTransferService {
         `Failed to update record: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
 
   async sendOtp(email: string) {
     if (!email) {
-      throw new RpcException('Email is required to send OTP');
+      throw new RpcException({
+        message: 'Email is required to send OTP',
+        code: 'EMAIL_REQUIRED_TO_SEND_OTP',
+      });
     }
 
     const defaultOpt = await this.db.otp.findUnique({ where: { email } });
@@ -515,21 +542,30 @@ export class GroupCashTransferService {
 
   private async verifyOtp(email?: string, otp?: string) {
     if (!email || !otp) {
-      throw new RpcException('Email and OTP are required');
+      throw new RpcException({
+        message: 'Email and OTP are required',
+        code: 'EMAIL_AND_OTP_REQUIRED',
+      });
     }
 
     const otpRecord = await this.db.otp.findUnique({ where: { email } });
     if (!otpRecord) {
-      throw new RpcException('OTP record not found');
+      throw new RpcException({
+        message: 'OTP record not found',
+        code: 'OTP_RECORD_NOT_FOUND',
+      });
     }
 
     if (otpRecord.expiresAt < new Date()) {
-      throw new RpcException('OTP has expired');
+      throw new RpcException({
+        message: 'OTP has expired',
+        code: 'OTP_EXPIRED',
+      });
     }
 
     const isValid = await bcrypt.compare(otp, otpRecord.otpHash);
     if (!isValid) {
-      throw new RpcException('Invalid OTP');
+      throw new RpcException({ message: 'Invalid OTP', code: 'INVALID_OTP' });
     }
 
     // consume OTP so it cannot be reused
@@ -549,15 +585,19 @@ export class GroupCashTransferService {
       });
 
       if (!record) {
-        throw new RpcException(
-          `Group cash transfer record ${recordUuid} not found`
-        );
+        throw new RpcException({
+          message: `Group cash transfer record ${recordUuid} not found`,
+          code: 'GCT_RECORD_NOT_FOUND',
+          params: { recordUuid },
+        });
       }
 
       if (record.status === 'COMPLETED') {
-        throw new RpcException(
-          `Record ${recordUuid} has already been disbursed`
-        );
+        throw new RpcException({
+          message: `Record ${recordUuid} has already been disbursed`,
+          code: 'RECORD_ALREADY_DISBURSED',
+          params: { recordUuid },
+        });
       }
 
       if (record.txHash) {
@@ -578,9 +618,11 @@ export class GroupCashTransferService {
 
       const balance = await this.treasuryService.getBalance();
       if (balance < (record.amount ?? 0)) {
-        throw new RpcException(
-          `Insufficient budget: treasury balance ${balance} is less than requested amount ${record.amount}`
-        );
+        throw new RpcException({
+          message: `Insufficient budget: treasury balance ${balance} is less than requested amount ${record.amount}`,
+          code: 'INSUFFICIENT_TREASURY_BUDGET',
+          params: { balance, amount: record.amount },
+        });
       }
 
       const offrampWallet = await this.offrampClient.getOfframpWalletAddress();
@@ -599,7 +641,11 @@ export class GroupCashTransferService {
             disbursementInfo: { error: error.message },
           },
         });
-        throw new RpcException(`Token transfer failed: ${error.message}`);
+        throw new RpcException({
+          message: `Token transfer failed: ${error.message}`,
+          code: 'TOKEN_TRANSFER_FAILED',
+          params: { message: error.message },
+        });
       }
 
       await this.db.groupCashTransferRecord.update({
@@ -622,6 +668,7 @@ export class GroupCashTransferService {
       };
     } catch (error: any) {
       this.logger.error(`Failed to disburse: ${error.message}`, error.stack);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -638,25 +685,34 @@ export class GroupCashTransferService {
       });
 
       if (!record) {
-        throw new RpcException(
-          `Group cash transfer record ${recordUuid} not found`
-        );
+        throw new RpcException({
+          message: `Group cash transfer record ${recordUuid} not found`,
+          code: 'GCT_RECORD_NOT_FOUND',
+          params: { recordUuid },
+        });
       }
 
       if (record.status === 'COMPLETED') {
-        throw new RpcException(
-          `Record ${recordUuid} has already been disbursed`
-        );
+        throw new RpcException({
+          message: `Record ${recordUuid} has already been disbursed`,
+          code: 'RECORD_ALREADY_DISBURSED',
+          params: { recordUuid },
+        });
       }
 
       if (!record.txHash) {
-        throw new RpcException('Transfer not initiated — call disburse first');
+        throw new RpcException({
+          message: 'Transfer not initiated — call disburse first',
+          code: 'TRANSFER_NOT_INITIATED',
+        });
       }
 
       if (!paymentProviderId) {
-        throw new RpcException(
-          'payoutProcessorId not set — call disburse with a payoutProcessorId first'
-        );
+        throw new RpcException({
+          message:
+            'payoutProcessorId not set — call disburse with a payoutProcessorId first',
+          code: 'PAYOUT_PROCESSOR_NOT_SET',
+        });
       }
 
       const bankDetails = (record.groupCashTransfer?.bankDetails as any) || {};
@@ -717,13 +773,18 @@ export class GroupCashTransferService {
             payoutProcessorId: paymentProviderId,
           },
         });
-        throw new RpcException(`Offramp request failed: ${error.message}`);
+        throw new RpcException({
+          message: `Offramp request failed: ${error.message}`,
+          code: 'OFFRAMP_REQUEST_FAILED',
+          params: { message: error.message },
+        });
       }
     } catch (error: any) {
       this.logger.error(
         `Failed to confirm disburse: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -736,6 +797,7 @@ export class GroupCashTransferService {
         `Failed to fetch treasury info: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -842,6 +904,7 @@ export class GroupCashTransferService {
         `Failed to fetch GCT overview data: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -858,7 +921,11 @@ export class GroupCashTransferService {
       const record = await this.findOneOrThrow(dto.groupUuid);
 
       if (!dto.bankId)
-        throw new RpcException(`Bank not found: ${dto.bankName}`);
+        throw new RpcException({
+          message: `Bank not found: ${dto.bankName}`,
+          code: 'BANK_NOT_FOUND',
+          params: { bankName: dto.bankName },
+        });
 
       const result = await this.offrampClient.validateBankAccount({
         bankId: dto.bankId,
@@ -919,6 +986,7 @@ export class GroupCashTransferService {
         `Failed to validate bank account: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -940,6 +1008,7 @@ export class GroupCashTransferService {
         `Failed to fetch valid group transfers: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -998,9 +1067,11 @@ export class GroupCashTransferService {
     );
     const hit = results.findIndex((r) => r !== null);
     if (hit !== -1)
-      throw new RpcException(
-        `A group with this ${checks[hit].field} already exists`
-      );
+      throw new RpcException({
+        message: `A group with this ${checks[hit].field} already exists`,
+        code: 'GROUP_WITH_THIS_FIELD_ALREADY_EXISTS',
+        params: { field: checks[hit].field },
+      });
   }
 
   private async findOneOrThrow(uuid: string) {
@@ -1009,7 +1080,11 @@ export class GroupCashTransferService {
     });
 
     if (!record) {
-      throw new RpcException(`Group cash transfer with UUID ${uuid} not found`);
+      throw new RpcException({
+        message: `Group cash transfer with UUID ${uuid} not found`,
+        code: 'GCT_NOT_FOUND',
+        params: { uuid },
+      });
     }
 
     return record;

--- a/apps/aa/src/inkinds/inkinds.service.ts
+++ b/apps/aa/src/inkinds/inkinds.service.ts
@@ -102,9 +102,11 @@ export class InkindsService {
       });
 
       if (existingInkind) {
-        throw new RpcException(
-          `Inkind with name '${inkindData.name}' already exists`
-        );
+        throw new RpcException({
+          message: `Inkind with name '${inkindData.name}' already exists`,
+          code: 'INKIND_NAME_ALREADY_EXISTS',
+          params: { name: inkindData.name },
+        });
       }
 
       const inkind = await this.prisma.$transaction(async (tx) => {
@@ -138,6 +140,7 @@ export class InkindsService {
         `Failed to create inkind: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -162,6 +165,7 @@ export class InkindsService {
         `Failed to update inkind: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -184,6 +188,7 @@ export class InkindsService {
         `Failed to delete inkind: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -275,6 +280,7 @@ export class InkindsService {
         `Failed to fetch inkinds: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -405,6 +411,7 @@ export class InkindsService {
         `Failed to fetch inkind summary: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -441,7 +448,11 @@ export class InkindsService {
     });
 
     if (!inkind) {
-      throw new RpcException(`Inkind with UUID ${uuid} not found`);
+      throw new RpcException({
+        message: `Inkind with UUID ${uuid} not found`,
+        code: 'INKIND_NOT_FOUND',
+        params: { uuid },
+      });
     }
 
     return inkind;
@@ -452,7 +463,10 @@ export class InkindsService {
     const { inkindId, quantity, groupInkindId, redemptionId } = payload;
 
     if (!inkindId || quantity == null || quantity <= 0) {
-      throw new RpcException('Missing or invalid required fields');
+      throw new RpcException({
+        message: 'Missing or invalid required fields',
+        code: 'MISSING_OR_INVALID_REQUIRED_FIELDS',
+      });
     }
 
     try {
@@ -476,6 +490,7 @@ export class InkindsService {
         `Failed to add inkind stock: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -522,6 +537,7 @@ export class InkindsService {
         `Failed to fetch inkind stock movements: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -532,7 +548,10 @@ export class InkindsService {
     this.logger.log(`Removing stock for inkind: ${inkindUuid}`);
 
     if (!inkindUuid) {
-      throw new RpcException('Missing inkindUuid field');
+      throw new RpcException({
+        message: 'Missing inkindUuid field',
+        code: 'MISSING_INKIND_UUID_FIELD',
+      });
     }
 
     try {
@@ -549,6 +568,7 @@ export class InkindsService {
         `Failed to remove inkind stock: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -574,6 +594,7 @@ export class InkindsService {
         `Failed to fetch unassigned groups for inkind ${uuid}: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -593,23 +614,34 @@ export class InkindsService {
     );
 
     if (!inkindId || !groupId || !mode) {
-      throw new RpcException('Missing required fields');
+      throw new RpcException({
+        message: 'Missing required fields',
+        code: 'MISSING_REQUIRED_FIELDS',
+      });
     }
 
     if (!(mode in PayoutMode)) {
-      throw new RpcException('Invalid payout mode');
+      throw new RpcException({
+        message: 'Invalid payout mode',
+        code: 'INVALID_PAYOUT_MODE',
+        params: { mode },
+      });
     }
 
     if (mode === PayoutMode.OFFLINE && !payoutProcessorId) {
-      throw new RpcException(
-        'payoutProcessorId is required for offline payouts'
-      );
+      throw new RpcException({
+        message: 'payoutProcessorId is required for offline payouts',
+        code: 'PAYOUT_PROCESSOR_ID_REQUIRED_FOR_OFFLINE',
+      });
     }
 
     const inkind = await this.findOneOrThrow(inkindId);
 
     if (inkind.type === InkindType.WALK_IN) {
-      throw new RpcException('Walk-in inkinds cannot be assigned to groups');
+      throw new RpcException({
+        message: 'Walk-in inkinds cannot be assigned to groups',
+        code: 'WALK_IN_INKINDS_CANNOT_BE_ASSIGNED',
+      });
     }
 
     const existingAssignment = await this.prisma.groupInkind.findFirst({
@@ -617,7 +649,10 @@ export class InkindsService {
     });
 
     if (existingAssignment) {
-      throw new RpcException(`Inkind is already assigned to this group.`);
+      throw new RpcException({
+        message: `Inkind is already assigned to this group.`,
+        code: 'INKIND_ALREADY_ASSIGNED_TO_GROUP',
+      });
     }
 
     const group = await this.prisma.beneficiaryGroups.findUnique({
@@ -626,22 +661,27 @@ export class InkindsService {
     });
 
     if (!group) {
-      throw new RpcException(`Group not found.`);
+      throw new RpcException({ message: `Group not found.`, code: 'GROUP_NOT_FOUND' });
     }
 
     const numberOfGroupBeneficiaries = group.beneficiaries.length;
 
     if (numberOfGroupBeneficiaries === 0) {
-      throw new RpcException(`No beneficiaries found in the group.`);
+      throw new RpcException({
+        message: `No beneficiaries found in the group.`,
+        code: 'NO_BENEFICIARIES_IN_GROUP',
+      });
     }
 
     const totalNeedInkindQuantity = newQuantity * numberOfGroupBeneficiaries;
     const availableStock = inkind.availableStock || 0;
 
     if (totalNeedInkindQuantity > availableStock) {
-      throw new RpcException(
-        `Not enough stock available. Requested: ${totalNeedInkindQuantity}, Available: ${availableStock}`
-      );
+      throw new RpcException({
+        message: `Not enough stock available. Requested: ${totalNeedInkindQuantity}, Available: ${availableStock}`,
+        code: 'INSUFFICIENT_INKIND_STOCK',
+        params: { requested: totalNeedInkindQuantity, available: availableStock },
+      });
     }
     try {
       await this.prisma.$transaction(async (tx) => {
@@ -722,6 +762,7 @@ export class InkindsService {
         `Failed to assign group inkind: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -787,6 +828,7 @@ export class InkindsService {
         `Failed to fetch inkinds by group: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -802,9 +844,10 @@ export class InkindsService {
     );
 
     if (!number && !walletAddress) {
-      throw new RpcException(
-        'Beneficiary phone number or wallet address is required'
-      );
+      throw new RpcException({
+        message: 'Beneficiary phone number or wallet address is required',
+        code: 'BENEFICIARY_PHONE_OR_WALLET_REQUIRED',
+      });
     }
 
     try {
@@ -844,6 +887,7 @@ export class InkindsService {
         `Failed to fetch inkind details for beneficiary: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -965,7 +1009,10 @@ export class InkindsService {
     );
 
     if (!vendorId) {
-      throw new RpcException('vendorId is required');
+      throw new RpcException({
+        message: 'vendorId is required',
+        code: 'VENDOR_ID_REQUIRED',
+      });
     }
 
     const vendor = await this.prisma.vendor.findUnique({
@@ -974,7 +1021,11 @@ export class InkindsService {
     });
 
     if (!vendor) {
-      throw new RpcException(`Vendor with UUID ${vendorId} not found`);
+      throw new RpcException({
+          message: `Vendor with UUID ${vendorId} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: vendorId },
+        });
     }
 
     const where: Prisma.BeneficiaryInkindRedemptionWhereInput = {
@@ -1045,7 +1096,10 @@ export class InkindsService {
         `Failed to fetch inkind redemption logs details for vendor: ${error.message}`,
         error.stack
       );
-      throw new RpcException('Failed to fetch inkind redemption logs details');
+      throw new RpcException({
+        message: 'Failed to fetch inkind redemption logs details',
+        code: 'FAILED_TO_FETCH_INKIND_REDEMPTION_LOGS',
+      });
     }
   }
 
@@ -1063,7 +1117,10 @@ export class InkindsService {
     this.logger.log(`Fetching inkind redemption logs for vendor: ${vendorId}`);
 
     if (!vendorId) {
-      throw new RpcException('vendorId is required');
+      throw new RpcException({
+        message: 'vendorId is required',
+        code: 'VENDOR_ID_REQUIRED',
+      });
     }
 
     try {
@@ -1073,7 +1130,11 @@ export class InkindsService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with UUID ${vendorId} not found`);
+        throw new RpcException({
+          message: `Vendor with UUID ${vendorId} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: vendorId },
+        });
       }
 
       const where: Prisma.BeneficiaryInkindRedemptionWhereInput = {
@@ -1198,6 +1259,7 @@ export class InkindsService {
         `Failed to fetch logs for vendor ${vendorId}: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1206,7 +1268,10 @@ export class InkindsService {
     this.logger.log(`Fetching redemption details for txHash: ${txHash}`);
 
     if (!vendorUid) {
-      throw new RpcException('vendorUid is required');
+      throw new RpcException({
+        message: 'vendorUid is required',
+        code: 'VENDOR_ID_REQUIRED',
+      });
     }
 
     try {
@@ -1234,7 +1299,11 @@ export class InkindsService {
         });
 
       if (redemptions.length === 0) {
-        throw new RpcException(`No redemptions found for txHash: ${txHash}`);
+        throw new RpcException({
+          message: `No redemptions found for txHash: ${txHash}`,
+          code: 'NO_REDEMPTIONS_FOUND_FOR_TXHASH',
+          params: { txHash },
+        });
       }
 
       const first = redemptions[0];
@@ -1257,6 +1326,7 @@ export class InkindsService {
         `Failed to fetch redemption details for txHash ${txHash}: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1275,7 +1345,10 @@ export class InkindsService {
     this.logger.log(`Fetching logs for groupInkindId: ${groupInkindId}`);
 
     if (!groupInkindId) {
-      throw new RpcException('groupInkindId is required');
+      throw new RpcException({
+        message: 'groupInkindId is required',
+        code: 'GROUP_INKIND_ID_REQUIRED',
+      });
     }
 
     try {
@@ -1296,9 +1369,11 @@ export class InkindsService {
       });
 
       if (!groupInkind) {
-        throw new RpcException(
-          `GroupInkind with UUID ${groupInkindId} not found`
-        );
+        throw new RpcException({
+          message: `GroupInkind with UUID ${groupInkindId} not found`,
+          code: 'GROUP_INKIND_NOT_FOUND',
+          params: { uuid: groupInkindId },
+        });
       }
 
       const where: Prisma.BeneficiaryInkindRedemptionWhereInput = {
@@ -1396,6 +1471,7 @@ export class InkindsService {
         `Failed to fetch logs for groupInkindId ${groupInkindId}: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1403,7 +1479,10 @@ export class InkindsService {
   async sendBeneficiaryOtp(number: string) {
     this.logger.log(`Sending OTP to beneficiary phone number: ${number}`);
     if (!number) {
-      throw new RpcException('Missing phone number');
+      throw new RpcException({
+        message: 'Missing phone number',
+        code: 'MISSING_PHONE_NUMBER',
+      });
     }
     const benf = await this.prisma.beneficiary.findFirst({
       where: {
@@ -1411,7 +1490,10 @@ export class InkindsService {
       },
     });
     if (!benf) {
-      throw new RpcException('Beneficiary not found');
+      throw new RpcException({
+        message: 'Beneficiary not found',
+        code: 'BENEFICIARY_NOT_FOUND',
+      });
     }
 
     const defaultOpt = await this.prisma.otp.findUnique({
@@ -1448,7 +1530,10 @@ export class InkindsService {
   async validateBeneficiaryOtp(number: string, otp: string) {
     this.logger.log(`Validating OTP for beneficiary phone number: ${number}`);
     if (!number || !otp) {
-      throw new RpcException('Missing phone number or OTP');
+      throw new RpcException({
+        message: 'Missing phone number or OTP',
+        code: 'MISSING_PHONE_NUMBER_OR_OTP',
+      });
     }
 
     const otpRecord = await this.prisma.otp.findUnique({
@@ -1456,7 +1541,10 @@ export class InkindsService {
     });
 
     if (!otpRecord) {
-      throw new RpcException('OTP record not found');
+      throw new RpcException({
+        message: 'OTP record not found',
+        code: 'OTP_RECORD_NOT_FOUND',
+      });
     }
 
     // if (otpRecord.isVerified) {
@@ -1470,7 +1558,7 @@ export class InkindsService {
 
     const isValid = await bcrypt.compare(otp, otpRecord.otpHash);
     if (!isValid) {
-      throw new RpcException('Invalid OTP');
+      throw new RpcException({ message: 'Invalid OTP', code: 'INVALID_OTP' });
     }
 
     await this.prisma.otp.update({
@@ -1489,9 +1577,11 @@ export class InkindsService {
     });
 
     if (!vendor) {
-      throw new RpcException(
-        `User '${user.name}' is not registered as a vendor`
-      );
+      throw new RpcException({
+        message: `User '${user.name}' is not registered as a vendor`,
+        code: 'USER_NOT_REGISTERED_AS_VENDOR',
+        params: { name: user.name },
+      });
     }
 
     const { value } = await this.appService.getSettings({
@@ -1513,9 +1603,10 @@ export class InkindsService {
       this.logger.log(
         'Payout phase not active. In-kind redemption is unavailable.'
       );
-      throw new RpcException(
-        'Payout phase not active. In-kind redemption is unavailable.'
-      );
+      throw new RpcException({
+        message: 'Payout phase not active. In-kind redemption is unavailable.',
+        code: 'PAYOUT_PHASE_NOT_ACTIVE_INKIND',
+      });
     }
 
     return vendor;
@@ -1540,7 +1631,10 @@ export class InkindsService {
       payload;
 
     if (!walletAddress || !inkinds || inkinds.length === 0) {
-      throw new RpcException('Missing required fields');
+      throw new RpcException({
+        message: 'Missing required fields',
+        code: 'MISSING_REQUIRED_FIELDS',
+      });
     }
 
     this.logger.log(
@@ -1554,9 +1648,11 @@ export class InkindsService {
         : await this.validateVendorAndPayoutPhase(user);
 
       if (!vendor) {
-        throw new RpcException(
-          `User '${user.name}' is not registered as a vendor`
-        );
+        throw new RpcException({
+          message: `User '${user.name}' is not registered as a vendor`,
+          code: 'USER_NOT_REGISTERED_AS_VENDOR',
+          params: { name: user.name },
+        });
       }
 
       // ===== STEP 1: Fetch and validate common data =====
@@ -1570,7 +1666,10 @@ export class InkindsService {
       }
 
       if (inkinds.length !== inkindRecords.length) {
-        throw new RpcException('One or more inkinds not found');
+        throw new RpcException({
+          message: 'One or more inkinds not found',
+          code: 'ONE_OR_MORE_INKINDS_NOT_FOUND',
+        });
       }
 
       const beneficiary =
@@ -1581,7 +1680,10 @@ export class InkindsService {
         }));
 
       if (!beneficiary) {
-        throw new RpcException('Beneficiary not found');
+        throw new RpcException({
+        message: 'Beneficiary not found',
+        code: 'BENEFICIARY_NOT_FOUND',
+      });
       }
 
       // ===== STEP 2: Categorize inkinds by type =====
@@ -1604,9 +1706,11 @@ export class InkindsService {
 
         if (inkindRecord.type === InkindType.PRE_DEFINED) {
           if (!payloadInkind.groupInkindUuid) {
-            throw new RpcException(
-              `Missing groupInkindUuid for PRE_DEFINED inkind: ${inkindRecord.name}`
-            );
+            throw new RpcException({
+              message: `Missing groupInkindUuid for PRE_DEFINED inkind: ${inkindRecord.name}`,
+              code: 'MISSING_GROUP_INKIND_UUID_FOR_PRE_DEFINED',
+              params: { name: inkindRecord.name },
+            });
           }
           preDefinedPayload.push({
             uuid: payloadInkind.uuid,
@@ -1712,6 +1816,7 @@ export class InkindsService {
         `Failed to redeem inkinds for beneficiary: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1751,6 +1856,7 @@ export class InkindsService {
         `Failed to update redemption txHash for beneficiary: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1769,9 +1875,10 @@ export class InkindsService {
 
     try {
       if (!beneficiaryUuid && !walletAddress) {
-        throw new RpcException(
-          'Either beneficiaryUuid or walletAddress is required'
-        );
+        throw new RpcException({
+          message: 'Either beneficiaryUuid or walletAddress is required',
+          code: 'BENEFICIARY_UUID_OR_WALLET_REQUIRED',
+        });
       }
 
       const beneficiary = await this.prisma.beneficiary.findFirst({
@@ -1788,7 +1895,10 @@ export class InkindsService {
       });
 
       if (!beneficiary) {
-        throw new RpcException('Beneficiary not found');
+        throw new RpcException({
+        message: 'Beneficiary not found',
+        code: 'BENEFICIARY_NOT_FOUND',
+      });
       }
 
       const [groupInkinds, redemptions, walkInInkinds] = await Promise.all([
@@ -1970,6 +2080,7 @@ export class InkindsService {
         `Failed to fetch beneficiary inkind details: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1980,7 +2091,10 @@ export class InkindsService {
     );
 
     if (!vendorId) {
-      throw new RpcException('vendorUid is required');
+      throw new RpcException({
+        message: 'vendorUid is required',
+        code: 'VENDOR_ID_REQUIRED',
+      });
     }
 
     try {
@@ -2120,6 +2234,7 @@ export class InkindsService {
         `Failed to fetch predefined offline beneficiaries for vendor: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2130,7 +2245,10 @@ export class InkindsService {
     batchSize = DEFAULT_BULK_BATCH_SIZE
   ) {
     if (!payloads || payloads.length === 0) {
-      throw new RpcException('No inkinds provided for redemption');
+      throw new RpcException({
+        message: 'No inkinds provided for redemption',
+        code: 'NO_INKINDS_PROVIDED_FOR_REDEMPTION',
+      });
     }
 
     this.logger.log(
@@ -2198,6 +2316,7 @@ export class InkindsService {
         `Failed to process bulk inkind redemptions for vendor: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2493,11 +2612,17 @@ export class InkindsService {
     );
 
     if (!user || !user.uuid) {
-      throw new RpcException('userUuid is required');
+      throw new RpcException({
+        message: 'userUuid is required',
+        code: 'USER_UUID_REQUIRED',
+      });
     }
 
     if (!redeemedInkinds || redeemedInkinds.length === 0) {
-      throw new RpcException('No inkinds provided for redemption');
+      throw new RpcException({
+        message: 'No inkinds provided for redemption',
+        code: 'NO_INKINDS_PROVIDED_FOR_REDEMPTION',
+      });
     }
 
     try {
@@ -2521,6 +2646,7 @@ export class InkindsService {
         `Failed to redeem offline inkinds for vendor: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2533,7 +2659,10 @@ export class InkindsService {
     );
 
     if (!vendorUuid) {
-      throw new RpcException('vendorUuid is required');
+      throw new RpcException({
+        message: 'vendorUuid is required',
+        code: 'VENDOR_ID_REQUIRED',
+      });
     }
 
     try {
@@ -2543,7 +2672,11 @@ export class InkindsService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with UUID ${vendorUuid} not found`);
+        throw new RpcException({
+          message: `Vendor with UUID ${vendorUuid} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: vendorUuid },
+        });
       }
 
       // Total earned per inkind: what the vendor collected from beneficiaries
@@ -2640,6 +2773,7 @@ export class InkindsService {
         `Failed to fetch total earned inkinds for vendor ${vendorUuid}: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2665,7 +2799,11 @@ export class InkindsService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with UUID ${vendorUuid} not found`);
+        throw new RpcException({
+          message: `Vendor with UUID ${vendorUuid} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: vendorUuid },
+        });
       }
     }
 
@@ -2723,6 +2861,7 @@ export class InkindsService {
         )}: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2739,11 +2878,17 @@ export class InkindsService {
     const projectId = this.configService.get('PROJECT_ID');
 
     if (!vendorUuid || !inkindUuid || !quantity) {
-      throw new RpcException('Missing required fields');
+      throw new RpcException({
+        message: 'Missing required fields',
+        code: 'MISSING_REQUIRED_FIELDS',
+      });
     }
 
     if (quantity <= 0) {
-      throw new RpcException('Quantity must be greater than zero');
+      throw new RpcException({
+        message: 'Quantity must be greater than zero',
+        code: 'QUANTITY_MUST_BE_GREATER_THAN_ZERO',
+      });
     }
 
     try {
@@ -2752,7 +2897,11 @@ export class InkindsService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with UUID ${vendorUuid} not found`);
+        throw new RpcException({
+          message: `Vendor with UUID ${vendorUuid} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: vendorUuid },
+        });
       }
 
       const inkind = await this.prisma.inkind.findUnique({
@@ -2760,7 +2909,11 @@ export class InkindsService {
       });
 
       if (!inkind) {
-        throw new RpcException(`Inkind with UUID ${inkindUuid} not found`);
+        throw new RpcException({
+          message: `Inkind with UUID ${inkindUuid} not found`,
+          code: 'INKIND_NOT_FOUND',
+          params: { uuid: inkindUuid },
+        });
       }
 
       const existingRedemption =
@@ -2773,9 +2926,10 @@ export class InkindsService {
         });
 
       if (existingRedemption) {
-        throw new RpcException(
-          `A pending redemption already exists for this vendor and inkind`
-        );
+        throw new RpcException({
+          message: `A pending redemption already exists for this vendor and inkind`,
+          code: 'PENDING_REDEMPTION_ALREADY_EXISTS',
+        });
       }
 
       const redemption = await this.prisma.vendorInkindRedemption.create({
@@ -2817,6 +2971,7 @@ export class InkindsService {
         `Failed to create vendor redemption: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2830,7 +2985,10 @@ export class InkindsService {
     );
 
     if (!uuid || !status) {
-      throw new RpcException('Missing required fields');
+      throw new RpcException({
+        message: 'Missing required fields',
+        code: 'MISSING_REQUIRED_FIELDS',
+      });
     }
 
     try {
@@ -2839,7 +2997,11 @@ export class InkindsService {
       });
 
       if (!redemption) {
-        throw new RpcException(`Vendor redemption with UUID ${uuid} not found`);
+        throw new RpcException({
+          message: `Vendor redemption with UUID ${uuid} not found`,
+          code: 'VENDOR_REDEMPTION_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       const vendorDetails = await this.prisma.vendor.findUnique({
@@ -2847,9 +3009,11 @@ export class InkindsService {
       });
 
       if (!vendorDetails) {
-        throw new RpcException(
-          `Vendor with UUID ${redemption.vendorUuid} not found`
-        );
+        throw new RpcException({
+          message: `Vendor with UUID ${redemption.vendorUuid} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: redemption.vendorUuid },
+        });
       }
       // now we have to create tx hash of this redemption and update the redemption record with that tx hash
 
@@ -2892,6 +3056,7 @@ export class InkindsService {
         `Failed to update vendor redemption status: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2902,7 +3067,10 @@ export class InkindsService {
     );
 
     if (!redemptionUuid || !txHash) {
-      throw new RpcException('Missing required fields');
+      throw new RpcException({
+        message: 'Missing required fields',
+        code: 'MISSING_REQUIRED_FIELDS',
+      });
     }
 
     try {
@@ -2924,6 +3092,7 @@ export class InkindsService {
         `Failed to update vendor redemption txHash: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -2955,18 +3124,23 @@ export class InkindsService {
     });
 
     if (groupInkinds.length !== groupInkindUuids.length) {
-      throw new RpcException('One or more PRE_DEFINED group inkinds not found');
+      throw new RpcException({
+        message: 'One or more PRE_DEFINED group inkinds not found',
+        code: 'PRE_DEFINED_GROUP_INKINDS_NOT_FOUND',
+      });
     }
 
     // Validate beneficiary membership
     for (const groupInkind of groupInkinds) {
       if (groupInkind.group.beneficiaries.length === 0) {
         const inkindRecord = inkindRecordMap.get(groupInkind.inkindId);
-        throw new RpcException(
-          `Beneficiary is not a member of group for inkind: ${
+        throw new RpcException({
+          message: `Beneficiary is not a member of group for inkind: ${
             inkindRecord?.name || groupInkind.inkindId
-          }`
-        );
+          }`,
+          code: 'BENEFICIARY_NOT_MEMBER_OF_GROUP_FOR_INKIND',
+          params: { inkindName: inkindRecord?.name || groupInkind.inkindId },
+        });
       }
     }
 
@@ -2984,11 +3158,13 @@ export class InkindsService {
       const alreadyRedeemed = existingRedemptions.map(
         (r) => r.groupInkind.inkind.name
       );
-      throw new RpcException(
-        `Beneficiary has already redeemed PRE_DEFINED inkinds: ${alreadyRedeemed.join(
+      throw new RpcException({
+        message: `Beneficiary has already redeemed PRE_DEFINED inkinds: ${alreadyRedeemed.join(
           ', '
-        )}`
-      );
+        )}`,
+        code: 'BENEFICIARY_ALREADY_REDEEMED_PRE_DEFINED_INKINDS',
+        params: { names: alreadyRedeemed.join(', ') },
+      });
     }
 
     // Build validated redemption items
@@ -3003,9 +3179,11 @@ export class InkindsService {
       );
 
       if (quantityPerBeneficiary <= 0) {
-        throw new RpcException(
-          `Invalid quantity allocation for PRE_DEFINED inkind: ${inkindRecord.name}`
-        );
+        throw new RpcException({
+          message: `Invalid quantity allocation for PRE_DEFINED inkind: ${inkindRecord.name}`,
+          code: 'INVALID_QUANTITY_ALLOCATION_FOR_PRE_DEFINED_INKIND',
+          params: { name: inkindRecord.name },
+        });
       }
 
       return {
@@ -3058,11 +3236,13 @@ export class InkindsService {
         const alreadyRedeemed = existingRedemptions.map(
           (r) => r.groupInkind.inkind.name
         );
-        throw new RpcException(
-          `Beneficiary has already redeemed WALK_IN inkinds: ${alreadyRedeemed.join(
+        throw new RpcException({
+          message: `Beneficiary has already redeemed WALK_IN inkinds: ${alreadyRedeemed.join(
             ', '
-          )}`
-        );
+          )}`,
+          code: 'BENEFICIARY_ALREADY_REDEEMED_WALK_IN_INKINDS',
+          params: { names: alreadyRedeemed.join(', ') },
+        });
       }
     }
 
@@ -3168,9 +3348,10 @@ export class InkindsService {
             beneficiaryUuid,
           ]);
           if (!res || !res.success) {
-            throw new RpcException(
-              'Failed to assign beneficiary to existing walk-in group'
-            );
+            throw new RpcException({
+              message: 'Failed to assign beneficiary to existing walk-in group',
+              code: 'FAILED_TO_ASSIGN_BENEFICIARY_TO_WALK_IN_GROUP',
+            });
           }
 
           // Add beneficiary to the walk-in group
@@ -3203,9 +3384,10 @@ export class InkindsService {
         ]);
 
         if (!res) {
-          throw new RpcException(
-            'Failed to create group and assign beneficiary for walk-in redemption'
-          );
+          throw new RpcException({
+            message: 'Failed to create group and assign beneficiary for walk-in redemption',
+            code: 'FAILED_TO_CREATE_WALK_IN_GROUP',
+          });
         }
 
         groupId = res.group.uuid;

--- a/apps/aa/src/otp/otp.service.ts
+++ b/apps/aa/src/otp/otp.service.ts
@@ -39,7 +39,10 @@ export class OtpService {
       const transportId = data.find((item: any) => item.name === 'SMS')?.cuid;
 
       if (!transportId || !appId || !url) {
-        throw new RpcException('SMS_TRANSPORT_ID, APP_ID, URL are required');
+        throw new RpcException({
+          message: 'SMS_TRANSPORT_ID, APP_ID, URL are required',
+          code: 'SMS_TRANSPORT_CONFIG_MISSING',
+        });
       }
 
       const finalMessage = `${message} ${otp}`;
@@ -54,7 +57,10 @@ export class OtpService {
       return { otp };
     } catch (error) {
       this.logger.error(`Error sending SMS: ${(error as any).message}`);
-      throw new RpcException('Failed to send SMS');
+      throw new RpcException({
+        message: 'Failed to send SMS',
+        code: 'FAILED_TO_SEND_SMS',
+      });
     }
   }
 
@@ -88,7 +94,10 @@ export class OtpService {
       return { otp };
     } catch (error: any) {
       this.logger.error(`Error sending email: ${error.message}`);
-      throw new RpcException('Failed to send email');
+      throw new RpcException({
+        message: 'Failed to send email',
+        code: 'FAILED_TO_SEND_EMAIL',
+      });
     }
   }
 

--- a/apps/aa/src/payouts/offramp.service.ts
+++ b/apps/aa/src/payouts/offramp.service.ts
@@ -40,15 +40,19 @@ export class OfframpService {
       name: 'OFFRAMP_SETTINGS',
     });
     if (!offrampSettings) {
-      throw new RpcException(`Offramp settings not found.`);
+      throw new RpcException({
+        message: `Offramp settings not found.`,
+        code: 'PAYOUT_ERR_OFFRAMP_SETTINGS_NOT_FOUND',
+      });
     }
     const url = offrampSettings?.value?.url as string;
     const appId = offrampSettings?.value?.appid as string;
     const accessToken = offrampSettings?.value?.accesstoken as string;
     if (!url || !appId || !accessToken) {
-      throw new RpcException(
-        `Offramp url/Appid/AccessToken not found in settings.`
-      );
+      throw new RpcException({
+        message: `Offramp url/Appid/AccessToken not found in settings.`,
+        code: 'PAYOUT_ERR_OFFRAMP_CONFIG_MISSING',
+      });
     }
 
     return {
@@ -122,9 +126,11 @@ export class OfframpService {
       return data.wallet;
     } catch (error) {
       console.log(error);
-      throw new RpcException(
-        `Failed to fetch offramp wallet address: ${error.message}`
-      );
+      throw new RpcException({
+        message: `Failed to fetch offramp wallet address: ${error.message}`,
+        code: 'PAYOUT_ERR_OFFRAMP_WALLET_FETCH',
+        params: { message: error.message },
+      });
     }
   }
 
@@ -156,11 +162,12 @@ export class OfframpService {
       console.log('#'.repeat(100));
       return data;
     } catch (error) {
-      throw new RpcException(
-        `Failed to initiate instant offramp: ${
-          error?.response?.data?.message || error?.message
-        }`
-      );
+      const errMsg = error?.response?.data?.message || error?.message;
+      throw new RpcException({
+        message: `Failed to initiate instant offramp: ${errMsg}`,
+        code: 'FAILED_TO_INITIATE_INSTANT_OFFRAMP',
+        params: { message: errMsg },
+      });
     }
   }
 
@@ -186,11 +193,12 @@ export class OfframpService {
 
       return data;
     } catch (error) {
-      throw new RpcException(
-        `Failed to initiate instant offramp: ${
-          error?.response?.data?.message || error?.message
-        }`
-      );
+      const errMsg = error?.response?.data?.message || error?.message;
+      throw new RpcException({
+        message: `Failed to initiate instant offramp: ${errMsg}`,
+        code: 'FAILED_TO_INITIATE_INSTANT_OFFRAMP_V2',
+        params: { message: errMsg },
+      });
     }
   }
 

--- a/apps/aa/src/payouts/payouts.service.ts
+++ b/apps/aa/src/payouts/payouts.service.ts
@@ -86,7 +86,10 @@ export class PayoutsService {
 
   async sendOtp(email: string) {
     if (!email) {
-      throw new RpcException('Email is required to send OTP');
+      throw new RpcException({
+        message: 'Email is required to send OTP',
+        code: 'EMAIL_REQUIRED_TO_SEND_OTP',
+      });
     }
 
     const defaultOpt = await this.prisma.otp.findUnique({ where: { email } });
@@ -129,21 +132,27 @@ export class PayoutsService {
 
   private async verifyOtp(email?: string, otp?: string) {
     if (!email || !otp) {
-      throw new RpcException('Email and OTP are required');
+      throw new RpcException({
+        message: 'Email and OTP are required',
+        code: 'EMAIL_AND_OTP_REQUIRED',
+      });
     }
 
     const otpRecord = await this.prisma.otp.findUnique({ where: { email } });
     if (!otpRecord) {
-      throw new RpcException('OTP record not found');
+      throw new RpcException({
+        message: 'OTP record not found',
+        code: 'OTP_RECORD_NOT_FOUND',
+      });
     }
 
     if (otpRecord.expiresAt < new Date()) {
-      throw new RpcException('OTP has expired');
+      throw new RpcException({ message: 'OTP has expired', code: 'OTP_EXPIRED' });
     }
 
     const isValid = await bcrypt.compare(otp, otpRecord.otpHash);
     if (!isValid) {
-      throw new RpcException('Invalid OTP');
+      throw new RpcException({ message: 'Invalid OTP', code: 'INVALID_OTP' });
     }
 
     // consume OTP so it cannot be reused
@@ -278,9 +287,11 @@ export class PayoutsService {
         });
 
       if (!beneficiaryGroupTokens) {
-        throw new RpcException(
-          `Beneficiary group tokens with UUID '${groupId}' not found`
-        );
+        throw new RpcException({
+          message: `Beneficiary group tokens with UUID '${groupId}' not found`,
+          code: 'PAYOUT_ERR_GROUP_TOKENS_NOT_FOUND',
+          params: { groupId },
+        });
       }
 
       this.validateGroupPurposeForPayoutType(
@@ -297,9 +308,11 @@ export class PayoutsService {
       });
 
       if (existingPayout) {
-        throw new RpcException(
-          `Payout with groupId '${groupId}' already exists`
-        );
+        throw new RpcException({
+          message: `Payout with groupId '${groupId}' already exists`,
+          code: 'PAYOUT_ERR_GROUP_PAYOUT_EXISTS',
+          params: { groupId },
+        });
       }
 
       /*
@@ -311,9 +324,10 @@ export class PayoutsService {
       //TODO validate bankdetails of the beneficiary
       if (createPayoutDto.type === 'FSP') {
         if (!createPayoutDto.payoutProcessorId) {
-          throw new RpcException(
-            `Payout processor ID is required for FSP payout`
-          );
+          throw new RpcException({
+            message: `Payout processor ID is required for FSP payout`,
+            code: 'PAYOUT_ERR_PROCESSOR_ID_REQUIRED_FSP',
+          });
         }
       } else {
         /*
@@ -323,13 +337,17 @@ export class PayoutsService {
          */
         if (createPayoutDto.mode === 'OFFLINE') {
           if (!createPayoutDto.payoutProcessorId) {
-            throw new RpcException(
-              `Payout processor ID is required for OFFLINE payout`
-            );
+            throw new RpcException({
+              message: `Payout processor ID is required for OFFLINE payout`,
+              code: 'PAYOUT_ERR_PROCESSOR_ID_REQUIRED_OFFLINE',
+            });
           }
 
           if (!isUUID(createPayoutDto.payoutProcessorId)) {
-            throw new RpcException(`Payout processor ID is not a valid UUID`);
+            throw new RpcException({
+              message: `Payout processor ID is not a valid UUID`,
+              code: 'PAYOUT_ERR_INVALID_PROCESSOR_ID',
+            });
           }
 
           const vendor = await this.vendorsService.findOne(
@@ -337,9 +355,11 @@ export class PayoutsService {
           );
 
           if (!vendor) {
-            throw new RpcException(
-              `Vendor with ID '${createPayoutDto.payoutProcessorId}' not found`
-            );
+            throw new RpcException({
+              message: `Vendor with ID '${createPayoutDto.payoutProcessorId}' not found`,
+              code: 'PAYOUT_ERR_VENDOR_NOT_FOUND',
+              params: { id: createPayoutDto.payoutProcessorId },
+            });
           }
         }
       }
@@ -404,6 +424,7 @@ export class PayoutsService {
         `Failed to create payout: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -424,9 +445,11 @@ export class PayoutsService {
       this.logger.warn(
         `Group purpose GENERAL not allowed for group: ${groupId} with payout type: ${payoutType}`
       );
-      throw new RpcException(
-        `Group purpose GENERAL is only allowed for VENDOR payouts. Received payout type: ${payoutType}.`
-      );
+      throw new RpcException({
+        message: `Group purpose GENERAL is only allowed for VENDOR payouts. Received payout type: ${payoutType}.`,
+        code: 'GROUP_PURPOSE_GENERAL_ONLY_FOR_VENDOR_PAYOUTS',
+        params: { payoutType },
+      });
     }
   }
 
@@ -696,7 +719,11 @@ export class PayoutsService {
 
       if (!payout) {
         this.logger.warn(`Payout not found with UUID: '${uuid}'`);
-        throw new RpcException(`Payout with UUID '${uuid}' not found`);
+        throw new RpcException({
+          message: `Payout with UUID '${uuid}' not found`,
+          code: 'PAYOUT_ERR_NOT_FOUND',
+          params: { uuid },
+        });
       }
       const calculatedStatus = calculatePayoutStatus(payout);
       await this.syncPayoutStatus(payout, calculatedStatus);
@@ -769,6 +796,7 @@ export class PayoutsService {
         `Failed to fetch payout: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -798,6 +826,7 @@ export class PayoutsService {
         `Failed to fetch payout: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -844,7 +873,11 @@ export class PayoutsService {
 
       if (!existingPayout) {
         this.logger.warn(`Payout not found with UUID: ${uuid}`);
-        throw new RpcException(`Payout with UUID '${uuid}' not found`);
+        throw new RpcException({
+          message: `Payout with UUID '${uuid}' not found`,
+          code: 'PAYOUT_ERR_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       const updatedPayout = await this.prisma.payouts.update({
@@ -859,6 +892,7 @@ export class PayoutsService {
         `Failed to update payout: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -914,9 +948,10 @@ export class PayoutsService {
       this.logger.error(
         `Some beneficiaries have null or undefined wallet addresses for payout with UUID: '${uuid}'`
       );
-      throw new RpcException(
-        'Some beneficiaries have missing wallet addresses'
-      );
+      throw new RpcException({
+        message: 'Some beneficiaries have missing wallet addresses',
+        code: 'PAYOUT_ERR_MISSING_WALLET_ADDRESSES',
+      });
     }
 
     this.logger.log(
@@ -1040,24 +1075,29 @@ export class PayoutsService {
       name: 'PROJECTINFO',
     });
     if (payoutDetails.isPayoutTriggered) {
-      throw new RpcException(
-        `Payout with UUID '${uuid}' has already been triggered`
-      );
+      throw new RpcException({
+        message: `Payout with UUID '${uuid}' has already been triggered`,
+        code: 'PAYOUT_ERR_ALREADY_TRIGGERED',
+        params: { uuid },
+      });
     }
 
     // Check if tokens have been disbursed to the beneficiary group
     // isDisbursed is set to true only after EVM/Stellar blockchain confirmation
     if (!payoutDetails.beneficiaryGroupToken?.isDisbursed) {
-      throw new RpcException(
-        `Payout cannot be triggered as tokens have not been disbursed to the beneficiary group "${payoutDetails.beneficiaryGroupToken.beneficiaryGroup.name}" yet. Please wait until the fund disbursement is completed and try again later.`
-      );
+      throw new RpcException({
+        message: `Payout cannot be triggered as tokens have not been disbursed to the beneficiary group "${payoutDetails.beneficiaryGroupToken.beneficiaryGroup.name}" yet. Please wait until the fund disbursement is completed and try again later.`,
+        code: 'PAYOUT_TRIGGER_TOKENS_NOT_DISBURSED',
+        params: { groupName: payoutDetails.beneficiaryGroupToken.beneficiaryGroup.name },
+      });
     }
 
     // Check if this is a manual bank transfer payout - these cannot be triggered
     if (payoutDetails.payoutProcessorId === 'manual-bank-transfer') {
-      throw new RpcException(
-        `Manual bank transfer payouts cannot be triggered. They are processed automatically upon creation.`
-      );
+      throw new RpcException({
+        message: `Manual bank transfer payouts cannot be triggered. They are processed automatically upon creation.`,
+        code: 'MANUAL_BANK_TRANSFER_PAYOUTS_CANNOT_BE_TRIGGERED',
+      });
     }
 
     const payoutExtras = payoutDetails.extras as {
@@ -1120,28 +1160,36 @@ export class PayoutsService {
         );
 
       if (!benfRedeemRequest) {
-        throw new RpcException(
-          `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' not found`
-        );
+        throw new RpcException({
+          message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' not found`,
+          code: 'PAYOUT_ERR_REDEEM_NOT_FOUND',
+          params: { uuid: beneficiaryRedeemUuid },
+        });
       }
 
       if (benfRedeemRequest.isCompleted)
-        throw new RpcException(
-          `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is already completed`
-        );
+        throw new RpcException({
+          message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is already completed`,
+          code: 'PAYOUT_ERR_REDEEM_ALREADY_COMPLETED',
+          params: { uuid: beneficiaryRedeemUuid },
+        });
 
       const transactionType = benfRedeemRequest.transactionType;
 
       if (transactionType === 'VENDOR_REIMBURSEMENT')
-        throw new RpcException(
-          `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is not a FSP Payout request`
-        );
+        throw new RpcException({
+          message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is not a FSP Payout request`,
+          code: 'PAYOUT_ERR_REDEEM_NOT_FSP',
+          params: { uuid: beneficiaryRedeemUuid },
+        });
 
       if (transactionType === 'TOKEN_TRANSFER') {
         if (benfRedeemRequest.status === 'TOKEN_TRANSACTION_INITIATED') {
-          throw new RpcException(
-            `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is already initiated`
-          );
+          throw new RpcException({
+            message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is already initiated`,
+            code: 'PAYOUT_ERR_REDEEM_ALREADY_INITIATED',
+            params: { uuid: beneficiaryRedeemUuid },
+          });
         }
         return await this.processOneFailedTokenTransferPayout({
           beneficiaryRedeemUuid,
@@ -1149,24 +1197,29 @@ export class PayoutsService {
       }
       if (transactionType === 'FIAT_TRANSFER') {
         if (benfRedeemRequest.status === 'FIAT_TRANSACTION_INITIATED') {
-          throw new RpcException(
-            `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is already initiated`
-          );
+          throw new RpcException({
+            message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is already initiated`,
+            code: 'PAYOUT_ERR_REDEEM_ALREADY_INITIATED',
+            params: { uuid: beneficiaryRedeemUuid },
+          });
         }
         return await this.processOneFailedFiatPayout({
           beneficiaryRedeemUuid,
         });
       }
 
-      throw new RpcException(
-        `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is not a FSP Payout request`
-      );
+      throw new RpcException({
+        message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' is not a FSP Payout request`,
+        code: 'PAYOUT_ERR_REDEEM_NOT_FSP',
+        params: { uuid: beneficiaryRedeemUuid },
+      });
     } catch (error) {
       this.logger.error(
         `Failed to trigger payout for failed request: ${error.message}`,
         error.stack
       );
 
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1183,22 +1236,27 @@ export class PayoutsService {
       const { payoutUUID } = payload;
 
       if (!payoutUUID) {
-        throw new RpcException(
-          'Payout UUID is required for failed payout request'
-        );
+        throw new RpcException({
+          message: 'Payout UUID is required for failed payout request',
+          code: 'PAYOUT_ERR_FAILED_UUID_REQUIRED',
+        });
       }
 
       const payout = await this.findOne(payoutUUID);
       if (!payout) {
-        throw new RpcException(
-          `Payout with UUID '${payoutUUID}' not found for failed payout request`
-        );
+        throw new RpcException({
+          message: `Payout with UUID '${payoutUUID}' not found for failed payout request`,
+          code: 'PAYOUT_ERR_FAILED_NOT_FOUND',
+          params: { uuid: payoutUUID },
+        });
       }
 
       if (!payout.isPayoutTriggered) {
-        throw new RpcException(
-          `Payout with UUID '${payoutUUID}' has not been triggered`
-        );
+        throw new RpcException({
+          message: `Payout with UUID '${payoutUUID}' has not been triggered`,
+          code: 'PAYOUT_ERR_NOT_TRIGGERED',
+          params: { uuid: payoutUUID },
+        });
       }
 
       const result =
@@ -1267,6 +1325,7 @@ export class PayoutsService {
         error.stack
       );
 
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1299,7 +1358,11 @@ export class PayoutsService {
       });
 
       if (!payout) {
-        throw new RpcException(`Payout with UUID '${payoutUUID}' not found`);
+        throw new RpcException({
+          message: `Payout with UUID '${payoutUUID}' not found`,
+          code: 'PAYOUT_ERR_NOT_FOUND',
+          params: { uuid: payoutUUID },
+        });
       }
 
       if (payout.type === 'VENDOR') {
@@ -1390,12 +1453,17 @@ export class PayoutsService {
         };
       }
 
-      throw new RpcException(`Unsupported payout type: ${payout.type}`);
+      throw new RpcException({
+        message: `Unsupported payout type: ${payout.type}`,
+        code: 'PAYOUT_ERR_UNSUPPORTED_TYPE',
+        params: { type: payout.type },
+      });
     } catch (error) {
       this.logger.error(
         `Failed to get payout log: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1424,9 +1492,11 @@ export class PayoutsService {
       });
 
       if (!log) {
-        throw new RpcException(
-          `Beneficiary redeem log with UUID '${uuid}' not found`
-        );
+        throw new RpcException({
+          message: `Beneficiary redeem log with UUID '${uuid}' not found`,
+          code: 'PAYOUT_ERR_REDEEM_LOG_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       // const info = log.info as Record<string, any> | null;
@@ -1439,6 +1509,7 @@ export class PayoutsService {
         `Failed to get payout log: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1481,6 +1552,7 @@ export class PayoutsService {
         error.stack
       );
 
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -1557,9 +1629,11 @@ export class PayoutsService {
       await this.beneficiaryService.getBeneficiaryRedeem(beneficiaryRedeemUuid);
 
     if (!benfRedeemRequest) {
-      throw new RpcException(
-        `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' not found`
-      );
+      throw new RpcException({
+        message: `Beneficiary redeem request with UUID '${beneficiaryRedeemUuid}' not found`,
+        code: 'PAYOUT_ERR_REDEEM_NOT_FOUND',
+        params: { uuid: beneficiaryRedeemUuid },
+      });
     }
 
     const benfExtras = benfRedeemRequest.Beneficiary.extras as {
@@ -1579,9 +1653,11 @@ export class PayoutsService {
 
     // check if offrampWalletAddress is in the info
     if (!info.offrampWalletAddress) {
-      throw new RpcException(
-        `Offramp wallet address not found for beneficiary redeem request with UUID '${beneficiaryRedeemUuid}'`
-      );
+      throw new RpcException({
+        message: `Offramp wallet address not found for beneficiary redeem request with UUID '${beneficiaryRedeemUuid}'`,
+        code: 'PAYOUT_ERR_REDEEM_OFFRAMP_WALLET_MISSING',
+        params: { uuid: beneficiaryRedeemUuid },
+      });
     }
 
     const beneficiaryPhoneNumber =
@@ -1620,7 +1696,10 @@ export class PayoutsService {
     });
 
     if (!projectInfo) {
-      throw new RpcException('Project info not found, in SETTINGS');
+      throw new RpcException({
+        message: 'Project info not found, in SETTINGS',
+        code: 'PAYOUT_ERR_PROJECT_INFO_NOT_FOUND',
+      });
     }
     const activeYear = projectInfo?.value?.active_year;
     const riverBasin = projectInfo?.value?.river_basin;
@@ -1743,15 +1822,19 @@ export class PayoutsService {
    */
   private validatePayoutUUID(payoutUUID: string): void {
     if (!payoutUUID) {
-      throw new RpcException(
-        'Payout verification failed: Payout UUID is required but was not provided'
-      );
+      throw new RpcException({
+        message:
+          'Payout verification failed: Payout UUID is required but was not provided',
+        code: 'PAYOUT_VERIFY_UUID_REQUIRED',
+      });
     }
 
     if (!isUUID(payoutUUID)) {
-      throw new RpcException(
-        `Payout verification failed: Invalid UUID format provided: '${payoutUUID}'`
-      );
+      throw new RpcException({
+        message: `Payout verification failed: Invalid UUID format provided: '${payoutUUID}'`,
+        code: 'PAYOUT_VERIFY_INVALID_UUID_FORMAT',
+        params: { payoutUUID },
+      });
     }
   }
 
@@ -1781,21 +1864,27 @@ export class PayoutsService {
       payout?.beneficiaryGroupToken &&
       !payout.beneficiaryGroupToken.isDisbursed
     ) {
-      throw new RpcException(
-        `Payout cannot be verified as tokens have not been disbursed to the beneficiary group "${payout.beneficiaryGroupToken.beneficiaryGroup.name}" yet. Please wait until the fund disbursement is completed and try again later.`
-      );
+      throw new RpcException({
+        message: `Payout cannot be verified as tokens have not been disbursed to the beneficiary group "${payout.beneficiaryGroupToken.beneficiaryGroup.name}" yet. Please wait until the fund disbursement is completed and try again later.`,
+        code: 'PAYOUT_VERIFY_TOKENS_NOT_DISBURSED',
+        params: { groupName: payout.beneficiaryGroupToken.beneficiaryGroup.name },
+      });
     }
 
     if (!payout) {
-      throw new RpcException(
-        `Payout verification failed: Payout with UUID '${payoutUUID}' not found in database`
-      );
+      throw new RpcException({
+        message: `Payout verification failed: Payout with UUID '${payoutUUID}' not found in database`,
+        code: 'PAYOUT_VERIFY_PAYOUT_NOT_FOUND',
+        params: { payoutUUID },
+      });
     }
 
     if (!payout.beneficiaryGroupToken?.beneficiaryGroup?.beneficiaries) {
-      throw new RpcException(
-        `Payout verification failed: No beneficiaries found for payout '${payoutUUID}'`
-      );
+      throw new RpcException({
+        message: `Payout verification failed: No beneficiaries found for payout '${payoutUUID}'`,
+        code: 'PAYOUT_VERIFY_NO_BENEFICIARIES_FOUND',
+        params: { payoutUUID },
+      });
     }
 
     return payout as PayoutWithBeneficiaryDetails;
@@ -1809,50 +1898,60 @@ export class PayoutsService {
     matchBy: ManualPayoutMatchBy = 'bankAccount'
   ): ManualPayoutRowData[] {
     if (!data || typeof data !== 'object') {
-      throw new RpcException(
-        'Payout verification failed: Invalid or missing payout data provided'
-      );
+      throw new RpcException({
+        message: 'Payout verification failed: Invalid or missing payout data provided',
+        code: 'PAYOUT_VERIFY_INVALID_DATA',
+      });
     }
 
     let rows = Object.values(data);
 
     if (rows.length === 0) {
-      throw new RpcException(
-        'Payout verification failed: No payout records found in provided data'
-      );
+      throw new RpcException({
+        message: 'Payout verification failed: No payout records found in provided data',
+        code: 'PAYOUT_VERIFY_NO_RECORDS_FOUND',
+      });
     }
 
     // Validate required fields in each row
     rows.forEach((row, index) => {
       if (!row['Transaction Status']) {
-        throw new RpcException(
-          `Payout verification failed: Missing transaction status in row ${
+        throw new RpcException({
+          message: `Payout verification failed: Missing transaction status in row ${
             index + 1
-          }`
-        );
+          }`,
+          code: 'PAYOUT_VERIFY_MISSING_TRANSACTION_STATUS',
+          params: { row: index + 1 },
+        });
       }
       if (matchBy === 'phoneNumber') {
         if (!row['Phone Number']) {
-          throw new RpcException(
-            `Payout verification failed: Missing phone number in row ${
+          throw new RpcException({
+            message: `Payout verification failed: Missing phone number in row ${
               index + 1
-            }`
-          );
+            }`,
+            code: 'PAYOUT_VERIFY_MISSING_PHONE_NUMBER',
+            params: { row: index + 1 },
+          });
         }
       } else {
         if (!row['Bank Account Number']) {
-          throw new RpcException(
-            `Payout verification failed: Missing bank account number in row ${
+          throw new RpcException({
+            message: `Payout verification failed: Missing bank account number in row ${
               index + 1
-            }`
-          );
+            }`,
+            code: 'PAYOUT_VERIFY_MISSING_BANK_ACCOUNT_NUMBER',
+            params: { row: index + 1 },
+          });
         }
         if (!row['Bank Account Holder Name ']) {
-          throw new RpcException(
-            `Payout verification failed: Missing bank account holder name in row ${
+          throw new RpcException({
+            message: `Payout verification failed: Missing bank account holder name in row ${
               index + 1
-            }`
-          );
+            }`,
+            code: 'PAYOUT_VERIFY_MISSING_BANK_ACCOUNT_HOLDER_NAME',
+            params: { row: index + 1 },
+          });
         }
       }
     });
@@ -1947,15 +2046,19 @@ export class PayoutsService {
   ): void {
     if (result.matched.length === 0) {
       if (matchBy === 'phoneNumber') {
-        throw new RpcException(
-          'Payout verification failed: No beneficiary phone numbers matched with the provided data. ' +
-            'Please verify that the phone numbers in your file match the registered beneficiaries.'
-        );
+        throw new RpcException({
+          message:
+            'Payout verification failed: No beneficiary phone numbers matched with the provided data. ' +
+            'Please verify that the phone numbers in your file match the registered beneficiaries.',
+          code: 'PAYOUT_VERIFY_NO_PHONE_MATCHES',
+        });
       }
-      throw new RpcException(
-        'Payout verification failed: No beneficiary bank accounts matched with the provided data. ' +
-          'Please verify that the bank account numbers in your file match the registered beneficiaries.'
-      );
+      throw new RpcException({
+        message:
+          'Payout verification failed: No beneficiary bank accounts matched with the provided data. ' +
+          'Please verify that the bank account numbers in your file match the registered beneficiaries.',
+        code: 'PAYOUT_VERIFY_NO_BANK_ACCOUNT_MATCHES',
+      });
     }
   }
 
@@ -1977,9 +2080,10 @@ export class PayoutsService {
 
     if (!isProjectCashTracker) {
       if (!deployerPrivateKey.value) {
-        throw new RpcException(
-          'Payout verification failed: Deployer private key not configured in system settings'
-        );
+        throw new RpcException({
+          message: 'Payout verification failed: Deployer private key not configured in system settings',
+          code: 'PAYOUT_VERIFY_DEPLOYER_KEY_NOT_CONFIGURED',
+        });
       }
 
       const deployerWalletAddress = new ethers.Wallet(
@@ -1992,25 +2096,28 @@ export class PayoutsService {
     const entitiesSettings = await this.settingService.getPublic('ENTITIES');
 
     if (!entitiesSettings?.value) {
-      throw new RpcException(
-        'Payout verification failed: Entity configuration not found in system settings'
-      );
+      throw new RpcException({
+        message: 'Payout verification failed: Entity configuration not found in system settings',
+        code: 'PAYOUT_VERIFY_ENTITY_CONFIG_NOT_FOUND',
+      });
     }
 
     const entities = entitiesSettings.value as unknown as EntityConfig[];
 
     if (!Array.isArray(entities)) {
-      throw new RpcException(
-        'Payout verification failed: Invalid entity configuration format in system settings'
-      );
+      throw new RpcException({
+        message: 'Payout verification failed: Invalid entity configuration format in system settings',
+        code: 'PAYOUT_VERIFY_INVALID_ENTITY_CONFIG_FORMAT',
+      });
     }
 
     const fieldOfficer = entities.find((entity) => entity.isFieldOffice);
 
     if (!fieldOfficer?.address) {
-      throw new RpcException(
-        'Payout verification failed: Field officer wallet address not configured in system settings'
-      );
+      throw new RpcException({
+        message: 'Payout verification failed: Field officer wallet address not configured in system settings',
+        code: 'PAYOUT_VERIFY_FIELD_OFFICER_ADDRESS_NOT_CONFIGURED',
+      });
     }
 
     this.logger.log(
@@ -2030,9 +2137,10 @@ export class PayoutsService {
       payout.beneficiaryGroupToken.beneficiaryGroup.beneficiaries.length;
 
     if (beneficiaryCount === 0) {
-      throw new RpcException(
-        'Payout verification failed: Cannot calculate token amount - no beneficiaries found'
-      );
+      throw new RpcException({
+        message: 'Payout verification failed: Cannot calculate token amount - no beneficiaries found',
+        code: 'PAYOUT_VERIFY_CANNOT_CALCULATE_TOKEN_AMOUNT',
+      });
     }
 
     const tokenAmountPerBeneficiary = totalTokens / beneficiaryCount;
@@ -2100,10 +2208,12 @@ export class PayoutsService {
         `Failed to add records to offramp verification queue: ${error.message}`,
         error.stack
       );
-      throw new RpcException(
-        'Payout verification completed but failed to queue offramp verification. ' +
-          'Manual intervention may be required.'
-      );
+      throw new RpcException({
+        message:
+          'Payout verification completed but failed to queue offramp verification. ' +
+          'Manual intervention may be required.',
+        code: 'PAYOUT_VERIFY_FAILED_TO_QUEUE_OFFRAMP',
+      });
     }
   }
 
@@ -2141,9 +2251,11 @@ export class PayoutsService {
       });
 
       if (!log) {
-        throw new RpcException(
-          `Beneficiary redeem log with UUID '${uuid}' not found`
-        );
+        throw new RpcException({
+          message: `Beneficiary redeem log with UUID '${uuid}' not found`,
+          code: 'PAYOUT_ERR_REDEEM_LOG_NOT_FOUND',
+          params: { uuid },
+        });
       }
 
       // 👇 if payout type is FSP, use your filtering function
@@ -2202,6 +2314,7 @@ export class PayoutsService {
         `Failed to get payout log: ${error.message}`,
         error.stack
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }

--- a/apps/aa/src/payouts/payouts.service.ts
+++ b/apps/aa/src/payouts/payouts.service.ts
@@ -255,7 +255,10 @@ export class PayoutsService {
       };
     } catch (error) {
       console.error('Failed to fetch payout stats:', error);
-      throw new Error('Failed to fetch payout stats');
+      throw new RpcException({
+        message: 'Failed to fetch payout stats',
+        code: 'FAILED_TO_FETCH_PAYOUT_STATS',
+      });
     }
   }
 
@@ -2407,11 +2410,16 @@ export class PayoutsService {
       });
 
       if (!settings?.value) {
-        throw new Error(`${key} not found`);
+        throw new RpcException({
+          message: `${key} not found`,
+          code: 'SETTING_KEY_NOT_FOUND',
+          params: { key },
+        });
       }
 
       return settings.value;
     } catch (error) {
+      if (error instanceof RpcException) throw error;
       this.logger.error(`Error getting setting ${key}: ${error.message}`);
       throw error;
     }

--- a/apps/aa/src/processors/evm-centralized.processor.ts
+++ b/apps/aa/src/processors/evm-centralized.processor.ts
@@ -150,7 +150,10 @@ export class EVMCentralizedProcessor implements OnModuleInit {
       const bens = await this.getBeneficiaryTokenBalance(groups);
 
       if (!bens || bens.length === 0) {
-        throw new RpcException('Beneficiary Token Balance not found');
+        throw new RpcException({
+          message: 'Beneficiary Token Balance not found',
+          code: 'STELLAR_ERR_TOKEN_BALANCE_NOT_FOUND',
+        });
       }
 
       const multicallTxnPayload = [];

--- a/apps/aa/src/stakeholders/stakeholders.controller.ts
+++ b/apps/aa/src/stakeholders/stakeholders.controller.ts
@@ -1,5 +1,5 @@
 import { Controller } from '@nestjs/common';
-import { MessagePattern } from '@nestjs/microservices';
+import { MessagePattern, RpcException } from '@nestjs/microservices';
 import { JOBS } from '../constants';
 import { StakeholdersService } from './stakeholders.service';
 import {
@@ -35,7 +35,10 @@ export class StakeholdersController {
   })
   async validateBulkStakeholders(payload: any) {
     if (!payload) {
-      throw new Error('No data provided for validation');
+      throw new RpcException({
+        message: 'No data provided for validation',
+        code: 'NO_STAKEHOLDERS_DATA_PROVIDED_FOR_VALIDATION',
+      });
     }
 
     const normalizedData = Array.isArray(payload)
@@ -50,7 +53,10 @@ export class StakeholdersController {
   })
   async bulkAdd(payloads: BulkAddStakeholdersPayload) {
     if (!payloads || !payloads?.data) {
-      throw new Error('Missing data in bulkAdd payload');
+      throw new RpcException({
+        message: 'Missing data in bulkAdd payload',
+        code: 'MISSING_DATA_IN_BULK_ADD_PAYLOAD',
+      });
     }
 
     const normalizedData = Array.isArray(payloads?.data)

--- a/apps/aa/src/stakeholders/stakeholders.service.ts
+++ b/apps/aa/src/stakeholders/stakeholders.service.ts
@@ -90,7 +90,10 @@ export class StakeholdersService {
       }
 
       if (stakeholderWithSamePhone)
-        throw new RpcException('Phone number must be unique');
+        throw new RpcException({
+          message: 'Phone number must be unique',
+          code: 'PHONE_NUMBER_MUST_BE_UNIQUE',
+        });
     }
 
     const rData = await this.prisma.stakeholders.create({
@@ -111,7 +114,10 @@ export class StakeholdersService {
     this.logger.log('Validating bulk stakeholders...');
 
     if (!payload || !payload.length) {
-      throw new RpcException('No stakeholder data provided for bulk add');
+      throw new RpcException({
+        message: 'No stakeholder data provided for bulk add',
+        code: 'NO_STAKEHOLDER_DATA_PROVIDED',
+      });
     }
 
     const errorsMap = new Map<string, StakeholderValidationError>();
@@ -161,21 +167,28 @@ export class StakeholdersService {
     this.logger.log('Adding bulk stakeholders...');
 
     if (!payload.data || !payload.data.length) {
-      throw new RpcException('No stakeholder data provided for bulk add');
+      throw new RpcException({
+        message: 'No stakeholder data provided for bulk add',
+        code: 'NO_STAKEHOLDER_DATA_PROVIDED',
+      });
     }
 
     if (payload?.isGroupCreate) {
       if (!payload?.groupName?.trim()) {
-        throw new RpcException(
-          'Group name is required when isGroupCreate is true'
-        );
+        throw new RpcException({
+          message: 'Group name is required when isGroupCreate is true',
+          code: 'GROUP_NAME_REQUIRED_FOR_CREATE',
+        });
       }
 
       const existingGroup = await this.prisma.stakeholdersGroups.findFirst({
         where: { name: payload.groupName },
       });
       if (existingGroup) {
-        throw new RpcException('Group name must be unique');
+        throw new RpcException({
+          message: 'Group name must be unique',
+          code: 'GROUP_NAME_MUST_BE_UNIQUE',
+        });
       }
     }
 
@@ -440,7 +453,11 @@ export class StakeholdersService {
       },
     });
 
-    if (!existingStakeholder) throw new RpcException('Stakeholder not found!');
+    if (!existingStakeholder)
+      throw new RpcException({
+        message: 'Stakeholder not found!',
+        code: 'STAKEHOLDER_NOT_FOUND',
+      });
 
     const validPhone = phone && phone.trim() !== '';
 
@@ -454,7 +471,10 @@ export class StakeholdersService {
         }
       );
       if (stakeholderWithSamePhone)
-        throw new RpcException('Phone number must be unique');
+        throw new RpcException({
+          message: 'Phone number must be unique',
+          code: 'PHONE_NUMBER_MUST_BE_UNIQUE',
+        });
     }
 
     const updatedStakeholder = await this.prisma.stakeholders.update({
@@ -499,7 +519,11 @@ export class StakeholdersService {
       },
     });
 
-    if (!existingGroup) throw new RpcException('Group not found!');
+    if (!existingGroup)
+      throw new RpcException({
+        message: 'Group not found!',
+        code: 'GROUP_NOT_FOUND',
+      });
 
     const data = {
       ...(name && { name }),
@@ -581,9 +605,11 @@ export class StakeholdersService {
 
       return groups;
     } catch (err) {
-      throw new RpcException(
-        `Error while fetching stakeholders groups by uuids. ${err.message}`
-      );
+      throw new RpcException({
+        message: `Error while fetching stakeholders groups by uuids. ${err.message}`,
+        code: 'FAILED_TO_FETCH_STAKEHOLDERS_GROUPS_BY_UUIDS',
+        params: { message: err.message },
+      });
     }
   }
 
@@ -608,9 +634,11 @@ export class StakeholdersService {
       });
       return groups;
     } catch (err) {
-      throw new RpcException(
-        `Error while fetching stakeholders groups by uuids. ${err.message}`
-      );
+      throw new RpcException({
+        message: `Error while fetching stakeholders groups by uuids. ${err.message}`,
+        code: 'FAILED_TO_FETCH_STAKEHOLDERS_GROUPS_BY_UUIDS',
+        params: { message: err.message },
+      });
     }
   }
 
@@ -640,7 +668,11 @@ export class StakeholdersService {
       },
     });
 
-    if (!existingGroup) throw new RpcException('Group not found!');
+    if (!existingGroup)
+      throw new RpcException({
+        message: 'Group not found!',
+        code: 'GROUP_NOT_FOUND',
+      });
 
     const activities = await this.getActivitiesByStakeholderGroupUuid(uuid);
 
@@ -677,9 +709,11 @@ export class StakeholdersService {
       );
       return activities;
     } catch (err) {
-      throw new RpcException(
-        `Error while fetching related activities. ${err.message}`
-      );
+      throw new RpcException({
+        message: `Error while fetching related activities. ${err.message}`,
+        code: 'FAILED_TO_FETCH_RELATED_ACTIVITIES',
+        params: { message: err.message },
+      });
     }
   }
 

--- a/apps/aa/src/vendors/vendorTokenRedemption.service.ts
+++ b/apps/aa/src/vendors/vendorTokenRedemption.service.ts
@@ -41,7 +41,11 @@ export class VendorTokenRedemptionService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with UUID ${dto.vendorUuid} not found`);
+        throw new RpcException({
+          message: `Vendor with UUID ${dto.vendorUuid} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: dto.vendorUuid },
+        });
       }
 
       // Check if a redemption request already exists with the same transaction hash
@@ -107,6 +111,7 @@ export class VendorTokenRedemptionService {
       return redemption;
     } catch (error) {
       this.logger.error(`Error creating token redemption: ${error.message}`);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -121,14 +126,17 @@ export class VendorTokenRedemptionService {
       });
 
       if (!redemption) {
-        throw new RpcException(
-          `Token redemption with UUID ${dto.uuid} not found`
-        );
+        throw new RpcException({
+          message: `Token redemption with UUID ${dto.uuid} not found`,
+          code: 'TOKEN_REDEMPTION_NOT_FOUND',
+          params: { uuid: dto.uuid },
+        });
       }
 
       return redemption;
     } catch (error) {
       this.logger.error(`Error finding token redemption: ${error.message}`);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -141,9 +149,11 @@ export class VendorTokenRedemptionService {
       });
 
       if (!redemption) {
-        throw new RpcException(
-          `Token redemption with UUID ${dto.uuid} not found`
-        );
+        throw new RpcException({
+          message: `Token redemption with UUID ${dto.uuid} not found`,
+          code: 'TOKEN_REDEMPTION_NOT_FOUND',
+          params: { uuid: dto.uuid },
+        });
       }
 
       // Only allow status updates from REQUESTED or STELLAR_VERIFIED to APPROVED or REJECTED
@@ -151,9 +161,11 @@ export class VendorTokenRedemptionService {
         redemption.redemptionStatus !== TokenRedemptionStatus.REQUESTED &&
         redemption.redemptionStatus !== TokenRedemptionStatus.STELLAR_VERIFIED
       ) {
-        throw new RpcException(
-          `Token redemption ${dto.uuid} is not in REQUESTED or STELLAR_VERIFIED status`
-        );
+        throw new RpcException({
+          message: `Token redemption ${dto.uuid} is not in REQUESTED or STELLAR_VERIFIED status`,
+          code: 'TOKEN_REDEMPTION_INVALID_STATUS_FOR_UPDATE',
+          params: { uuid: dto.uuid },
+        });
       }
 
       if (
@@ -164,9 +176,10 @@ export class VendorTokenRedemptionService {
           TokenRedemptionStatus.STELLAR_FAILED,
         ].includes(dto.redemptionStatus)
       ) {
-        throw new RpcException(
-          `Invalid status update. Only APPROVED, REJECTED, STELLAR_VERIFIED, or STELLAR_FAILED status is allowed`
-        );
+        throw new RpcException({
+          message: `Invalid status update. Only APPROVED, REJECTED, STELLAR_VERIFIED, or STELLAR_FAILED status is allowed`,
+          code: 'TOKEN_REDEMPTION_INVALID_TARGET_STATUS',
+        });
       }
 
       let updatedRedemption;
@@ -215,6 +228,7 @@ export class VendorTokenRedemptionService {
       return updatedRedemption;
     } catch (error) {
       this.logger.error(`Error updating token redemption: ${error.message}`);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -270,6 +284,7 @@ export class VendorTokenRedemptionService {
       );
     } catch (error) {
       this.logger.error(`Error listing token redemptions: ${error.message}`);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -288,6 +303,7 @@ export class VendorTokenRedemptionService {
       return redemptions;
     } catch (error) {
       this.logger.error(`Error getting vendor redemptions: ${error.message}`);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -302,7 +318,11 @@ export class VendorTokenRedemptionService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with UUID ${dto.vendorUuid} not found`);
+        throw new RpcException({
+          message: `Vendor with UUID ${dto.vendorUuid} not found`,
+          code: 'VENDOR_TOKEN_REDEMPTION_VENDOR_NOT_FOUND',
+          params: { uuid: dto.vendorUuid },
+        });
       }
 
       // Get total tokens approved (APPROVED + STELLAR_VERIFIED statuses)
@@ -344,6 +364,7 @@ export class VendorTokenRedemptionService {
       this.logger.error(
         `Error getting vendor token redemption stats: ${error.message}`
       );
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }

--- a/apps/aa/src/vendors/vendors.service.ts
+++ b/apps/aa/src/vendors/vendors.service.ts
@@ -64,7 +64,10 @@ export class VendorsService {
     this.logger.log(`Updating vendor details for ${uuid}`);
 
     if (!uuid) {
-      throw new RpcException('Either id or uuid must be provided');
+      throw new RpcException({
+        message: 'Either id or uuid must be provided',
+        code: 'VENDOR_ID_OR_UUID_REQUIRED',
+      });
     }
 
     try {
@@ -73,7 +76,10 @@ export class VendorsService {
       });
 
       if (!vendorDetails) {
-        throw new RpcException('Vendor not found');
+        throw new RpcException({
+          message: 'Vendor not found',
+          code: 'VENDOR_NOT_FOUND_GENERIC',
+        });
       }
 
       return this.prisma.vendor.update({
@@ -82,6 +88,7 @@ export class VendorsService {
       });
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -126,7 +133,11 @@ export class VendorsService {
       });
 
       if (!vendor) {
-        throw new RpcException(`Vendor with id ${vendorWallet.uuid} not found`);
+        throw new RpcException({
+          message: `Vendor with id ${vendorWallet.uuid} not found`,
+          code: 'VENDOR_NOT_FOUND',
+          params: { uuid: vendorWallet.uuid },
+        });
       }
 
       // TODO: STELLAR DETACH - re-enable vendor on-chain balance lookup once the
@@ -161,6 +172,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -194,6 +206,7 @@ export class VendorsService {
       return totalAssignedTokens;
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -215,6 +228,7 @@ export class VendorsService {
       return result._sum.amount || 0;
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -230,12 +244,16 @@ export class VendorsService {
       });
 
       if (!redemptionRequest.length) {
-        throw new RpcException('No redemption requests found for vendor');
+        throw new RpcException({
+          message: 'No redemption requests found for vendor',
+          code: 'NO_REDEMPTION_REQUESTS',
+        });
       }
 
       return redemptionRequest;
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -321,6 +339,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -340,9 +359,11 @@ export class VendorsService {
       });
 
       if (!transactions) {
-        throw new RpcException(
-          `Transactions not found for vendor with id ${walletBalanceDto.uuid}`
-        );
+        throw new RpcException({
+          message: `Transactions not found for vendor with id ${walletBalanceDto.uuid}`,
+          code: 'VENDOR_TRANSACTIONS_NOT_FOUND',
+          params: { uuid: walletBalanceDto.uuid },
+        });
       }
 
       const beneficiaryWalletAddresses = transactions.map(
@@ -357,7 +378,10 @@ export class VendorsService {
       );
 
       if (!benResponse) {
-        throw new RpcException(`Failed to get beneficiaries info`);
+        throw new RpcException({
+          message: `Failed to get beneficiaries info`,
+          code: 'VENDOR_BENEFICIARIES_INFO_FAILED',
+        });
       }
 
       return transactions.map((txn) => {
@@ -374,6 +398,7 @@ export class VendorsService {
       });
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -390,9 +415,11 @@ export class VendorsService {
       });
 
       if (!vendor) {
-        throw new RpcException(
-          `Vendor with id ${payload.vendorUuid} not found`
-        );
+        throw new RpcException({
+          message: `Vendor with id ${payload.vendorUuid} not found`,
+          code: 'VENDOR_NOT_FOUND',
+          params: { uuid: payload.vendorUuid },
+        });
       }
 
       // Build where clause for beneficiary redeem query
@@ -511,6 +538,7 @@ export class VendorsService {
       );
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -537,6 +565,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -563,6 +592,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -576,7 +606,11 @@ export class VendorsService {
       where: { uuid: payload.vendorUuid },
     });
     if (!vendor) {
-      throw new RpcException(`Vendor with id ${payload.vendorUuid} not found`);
+      throw new RpcException({
+      message: `Vendor with id ${payload.vendorUuid} not found`,
+      code: 'VENDOR_NOT_FOUND',
+      params: { uuid: payload.vendorUuid },
+    });
     }
 
     const pending = await this.prisma.beneficiaryRedeem.findMany({
@@ -675,6 +709,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -693,9 +728,11 @@ export class VendorsService {
       });
 
       if (!vendor) {
-        throw new RpcException(
-          `Vendor with id ${payload.vendorUuid} not found`
-        );
+        throw new RpcException({
+          message: `Vendor with id ${payload.vendorUuid} not found`,
+          code: 'VENDOR_NOT_FOUND',
+          params: { uuid: payload.vendorUuid },
+        });
       }
 
       // Get OTP data for the phone number
@@ -770,6 +807,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -787,9 +825,11 @@ export class VendorsService {
         where: { uuid: payload.vendorUuid },
       });
       if (!vendor) {
-        throw new RpcException(
-          `Vendor with id ${payload.vendorUuid} not found`
-        );
+        throw new RpcException({
+          message: `Vendor with id ${payload.vendorUuid} not found`,
+          code: 'VENDOR_NOT_FOUND',
+          params: { uuid: payload.vendorUuid },
+        });
       }
 
       // Find all beneficiaryRedeem records for this vendor
@@ -896,6 +936,7 @@ export class VendorsService {
       return beneficiaries;
     } catch (error) {
       this.logger.error(error.message);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }
@@ -910,9 +951,11 @@ export class VendorsService {
         where: { uuid: payload.vendorUuid },
       });
       if (!vendor) {
-        throw new RpcException(
-          `Vendor with id ${payload.vendorUuid} not found`
-        );
+        throw new RpcException({
+          message: `Vendor with id ${payload.vendorUuid} not found`,
+          code: 'VENDOR_NOT_FOUND',
+          params: { uuid: payload.vendorUuid },
+        });
       }
 
       // Get verified beneficiary UUIDs + OTP map
@@ -1001,6 +1044,7 @@ export class VendorsService {
       };
     } catch (error) {
       this.logger.error(`Error syncing vendor offline data: ${error.message}`);
+      if (error instanceof RpcException) throw error;
       throw new RpcException(error.message);
     }
   }

--- a/libs/cva/src/lib/communication/communication.service.ts
+++ b/libs/cva/src/lib/communication/communication.service.ts
@@ -49,18 +49,38 @@ export class CvaCommunicationService {
 
   async triggerCommunication(dto: TriggerCommunicationDto) {
     const comm = await this.findOne(dto.communicationId);
-    if (!comm) throw new RpcException('Communication not found');
+    if (!comm)
+      throw new RpcException({
+        message: 'Communication not found',
+        code: 'ACTIVITY_COMMUNICATION_NOT_FOUND',
+      });
     const { sessionId, transportId, groupUID, message } = comm;
-    if (!groupUID) throw new RpcException('Group not found');
-    if (sessionId) throw new RpcException('Communication already triggered');
+    if (!groupUID)
+      throw new RpcException({
+        message: 'Group not found',
+        code: 'GROUP_NOT_FOUND',
+      });
+    if (sessionId)
+      throw new RpcException({
+        message: 'Communication already triggered',
+        code: 'COMMUNICATION_ALREADY_TRIGGERED',
+      });
     const transport = await this.commsClient.transport.get(transportId);
-    if (!transport) throw new RpcException('Transport not found');
+    if (!transport)
+      throw new RpcException({
+        message: 'Transport not found',
+        code: 'SELECTED_TRANSPORT_NOT_FOUND',
+      });
     const beneficiaries = await this.listBenefByGroup(groupUID);
     const addresses = this.pickPhoneOrEmail(
       beneficiaries,
       transport.data?.type
     );
-    if (!addresses.length) throw new RpcException('No valid addresses found!');
+    if (!addresses.length)
+      throw new RpcException({
+        message: 'No valid addresses found!',
+        code: 'NO_VALID_ADDRESSES_FOUND',
+      });
     return this.broadcastMessages({
       uuid: dto.communicationId,
       addresses,


### PR DESCRIPTION
**What changed**

- Converted error throws across the service's core business logic from free-text-only exceptions to ones carrying a stable identifier alongside the existing English message.
- Added structured parameters for messages that interpolate a runtime value (identifiers, amounts, statuses), so a localized template can place the value correctly instead of inheriting an English sentence fragment.
- Applied the same code-prefix convention to custom validation-decorator messages on request payloads whose transport layer does not preserve a separate error-code field, so those errors remain translatable end to end.
- Fixed a structural defect in the shared validation-exception factory: it was nesting the error payload as an object where a flat string message was expected by every downstream consumer of that error, silently breaking message rendering for any validation failure on the affected endpoint. It now returns the first failing constraint as a flat, translatable summary string, while the complete per-field error detail is still carried separately for callers that want it.

**Approach**

- Code, not text, is the translation key. Each converted error now carries a stable identifier alongside its existing English message, so the message keeps working unchanged for any consumer not going through translation, while the frontend can key a localized lookup off the identifier when present.
- Structured parameters for dynamic values. Runtime values are passed as separate parameters rather than baked into the English sentence, preserving correct word order and grammar once localized.
- Bracket-prefix convention for validation-decorator messages. For request-payload validators whose error only carries a message string by the time it reaches the frontend, the identifier travels as a parseable prefix on that string instead, since decorator messages have no separate structured-payload channel.
- Scoped strictly to reachability. Only error sites confirmed reachable from a live, in-scope UI flow were converted. Paths that only surface on technical/admin-only views, are dead or unreferenced, or fire only in isolated per-item error-collection logic (where errors are aggregated rather than surfaced individually) were deliberately left untouched.
- No behavior change for existing consumers, aside from the one explicitly called-out structural fix above. Every other conversion preserves the original status and English message text exactly; the identifier and parameters are additive fields only.